### PR TITLE
Add multi targeting to projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     types: [ published ]
 
 env:
-  DotNetVersion: "7.0.107"
+  DotNetVersion: "8.0.401"
   BuildParameters: "/v:Minimal /consoleLoggerParameters:NoSummary /p:Configuration=Release /p:BuildVersion=${{ github.run_id }} /p:BuildBranch=${{ github.ref }}"
 
 jobs:
@@ -36,69 +36,31 @@ jobs:
       run: msbuild /restore ${{ env.BuildParameters }} /p:VSVersion=2022 Rhino.VisualStudio.Windows\Rhino.VisualStudio.Windows.csproj /bl:artifacts/log/Build.Windows.2022.binlog
 
     - name: Upload extensions
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: extensions-windows
         path: artifacts/Release/*.vsix
 
+    - name: Upload templates
+      uses: actions/upload-artifact@v4
+      with:
+        name: templates
+        path: artifacts/bin/Rhino.Templates/Release/*.nupkg
+
     - name: Upload log files
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: log
         path: artifacts/log/**/*
 
-  build-mac:
-
-    runs-on: macos-11
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DotNetVersion }}
-
-    - name: Install macos workload
-      run: sudo dotnet workload install macos --from-rollback-file dotnet-workloads.json
-        
-    - name: Setup Xamarin and XCode
-      uses: maxim-lobanov/setup-xamarin@v1
-      with:
-        mono-version: latest
-        xamarin-mac-version: latest
-        xcode-version: latest
-    
-    # - name: Build VS2019
-    #   run: msbuild /restore ${{ env.BuildParameters }} /t:PackageAddin /p:VSVersion=2019 src/Eto.DevExtension.VisualStudio.Mac/Eto.DevExtension.VisualStudio.Mac.csproj /bl:artifacts/log/Build.Mac.2019.binlog
-
-    - name: Build VS2022
-      run: dotnet build ${{ env.BuildParameters }} /p:VSVersion=2022 Rhino.VisualStudio.Mac/Rhino.VisualStudio.Mac.csproj /bl:artifacts/log/Build.Mac.2022.binlog
-
-    - name: Upload extensions
-      uses: actions/upload-artifact@v2
-      with:
-        name: extensions-mac
-        path: artifacts/Release/*.mpack
-
-    - name: Upload log files
-      if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: log
-        path: |
-          artifacts/log/**/*
-  
   publish:
-    needs: [ build-windows-2022, build-mac ]
+    needs: [ build-windows-2022 ]
     runs-on: ubuntu-latest
     if: (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
 
       - name: Display structure of downloaded files
         run: ls -R
@@ -110,4 +72,4 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             extensions-windows/*.vsix
-            extensions-mac/*.mpack
+            templates/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,17 +18,17 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DotNetVersion }}
 
     - name: Setup msbuild
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
       with:
         vs-version: '[17.0,18.0)'
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-	"omnisharp.defaultLaunchSolution": "Rhino.VisualStudio.Mac.sln",
 	"var": {
 		"configuration" : "Debug",
 		"buildProperties" : "/v:Minimal /p:GenerateFullPaths=True /consoleLoggerParameters:NoSummary"
 	},
+	"dotnet.defaultSolution": "Rhino.VisualStudio.Mac.sln",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -74,7 +74,7 @@
         "build",
         "/p:Configuration=${input:configuration}",
         "/p:GenerateFullPaths=true",
-        "/consoleloggerparameters:NoSummary",
+        "-clp:NoSummary",
         "${workspaceFolder}/Rhino.Templates/Rhino.Templates.csproj"
       ],
       "problemMatcher": "$msCompile",

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <BaseOutputPath>$(ArtifactsDir)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <BaseIntermediateOutputPath>$(ArtifactsDir)obj\$(OS)\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
 
-    <Version>8.0.0</Version> <!-- PSST. Hey Curtis. Update all other files with this number too -->
+    <Version>8.10.0</Version> <!-- PSST. Hey Curtis. Update all other files with this number too -->
     <PackageVersion>$(Version)</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,26 +1,8 @@
 # RhinoCommon Visual Studio Extensions
 
-Includes RhinoCommon and Grasshopper template wizards for Visual Studio on Windows and Mac.
+Includes RhinoCommon, Grasshopper, Zoo, and Rhino C++ templates and wizards for Visual Studio on Windows and Mac.
 
-Manual Install Instructions (Mac)
----------------------------------
-
-1. As of this writing, update to **Visual Studio for Mac 2022 v17.3 or later**.
-2. Download [the latest .mpack release](https://github.com/mcneel/RhinoVisualStudioExtensions/releases).
-3. Launch **Visual Studio for Mac**.
-4. Navigate to **Visual Studio** > **Extensions...**
-5. Click on the **Installed** tab
-6. **Uninstall** all previous versions of the **RhinoCommon Plugin Support**.  If none are installed, you can ignore the next two steps (skip to step 9).
-7. **Quit** and **Restart** Visual Studio for Mac.
-8. Navigate to **Visual Studio** > **Extensions...** again.
-9. Click **Install from file...** button in the lower-left corner.
-10. Navigate to the mpack file you downloaded in step 1, then click **Open**.
-11. Click **Install**.  The plugin should install.
-12. **Quit** and **Restart** Visual Studio for Mac.
-13. Navigate to **Visual Studio** > **Extensions..** > **Installed** tab.  Verify that **RhinoCommon Plugin Support** is listed.  If it's there, you have successfully installed the extension and you are **DONE**.
-
-Manual Install Instructions (Windows)
--------------------------------------
+## Manual Install Instructions (Visual Studio)
 
 1. Download [the latest .vsix release](https://github.com/mcneel/RhinoVisualStudioExtensions/releases).
 2. Close any instances of Visual Studio.
@@ -28,23 +10,22 @@ Manual Install Instructions (Windows)
 4. Run through the wizard to install the extension.
 5. Start Visual Studio and create a new RhinoCommon or Grasshopper project.
 
-Using dotnet new
-----------------
+## Using dotnet new
 
 1. Install the templates from nuget. This will show the list of all templates after a successful install.
 
-    `dotnet new -i Rhino.Templates`
+    `dotnet new install Rhino.Templates`
 
 2. Create a new folder for your project:
 
-    ```
+    ```bash
     mkdir MyNewRhinoPlugin
     cd MyNewRhinoPlugin
     ```
 
-3. Show options for the templates: 
+3. Show options for the templates:
 
-    ```
+    ```bash
     dotnet new rhino --help
     dotnet new grasshopper --help
     ```
@@ -57,15 +38,6 @@ Using dotnet new
 
     `dotnet build`
 
+## Additional Resources
 
-Debugging Rhino
----------------
-
-1. Click the **Run** button in the upper left-hand corner of Visual Studio
-
-For Developers (of this Extension)
---------------
-
-## Mac
-Building this project requires the **Addin Maker Extension**.  You can install this from within Visual Studio by navigating to **Visual Studio** > **Extensions...** > **Gallery** > **Extension Development** > **AddinMaker**.  Click the **Install** button.  **Quit** and **relaunch** Visual Studio for Mac.
-
+See <https://developer.rhino3d.com/guides/rhinocommon/> for guides on how to start with Rhino Plug-In development.

--- a/Rhino.Templates/README.md
+++ b/Rhino.Templates/README.md
@@ -1,0 +1,7 @@
+# Rhino 3D Templates
+
+RhinoCommon, Grasshopper and C++ SDK templates for [Rhino 3D](https://rhino3d.com).
+
+To install the templates in this package, run `dotnet new install Rhino.Templates` from the command line.
+
+See [developer.rhino3d.com](https://developer.rhino3d.com) to get started with Rhino 3D development.

--- a/Rhino.Templates/Rhino.Templates.csproj
+++ b/Rhino.Templates/Rhino.Templates.csproj
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://developer.rhino3d.com/guides/</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/mcneel/RhinoVisualStudioExtensions.git</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
 	
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ContentTargetFolders>content</ContentTargetFolders>
@@ -36,6 +37,7 @@
 
 	<ItemGroup>
     <None Include="rhinocommon.png" Pack="true" PackagePath=""/>
+    <None Include="README.md" Pack="true" PackagePath=""/>
 		<None Include="content\Directory.*" />
     <None Include="content\*\.template.config" />
     

--- a/Rhino.Templates/content/CPPRhino/.template.config/template.json
+++ b/Rhino.Templates/content/CPPRhino/.template.config/template.json
@@ -47,7 +47,7 @@
       "type": "parameter",
       "description": "Version of Rhino",
       "datatype": "choice",
-      "defaultValue": "7",
+      "defaultValue": "8",
       "choices": [
         {
           "choice": "7",
@@ -55,7 +55,7 @@
         },
         {
           "choice": "8",
-          "description": "Version 8 (WIP)"
+          "description": "Version 8"
         }
       ]
     },

--- a/Rhino.Templates/content/CPPRhino/MyRhino.1.vcxproj
+++ b/Rhino.Templates/content/CPPRhino/MyRhino.1.vcxproj
@@ -65,14 +65,18 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset Condition="$(RhinoVersion) == '6'">v142</PlatformToolset>
+    <PlatformToolset Condition="$(RhinoVersion) == '7'">v142</PlatformToolset>
+    <PlatformToolset Condition="$(RhinoVersion) == '8' || $(RhinoVersion) == ''">v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset Condition="$(RhinoVersion) == '6'">v142</PlatformToolset>
+    <PlatformToolset Condition="$(RhinoVersion) == '7'">v142</PlatformToolset>
+    <PlatformToolset Condition="$(RhinoVersion) == '8' || $(RhinoVersion) == ''">v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
   </PropertyGroup>

--- a/Rhino.Templates/content/CPPSkin/.template.config/template.json
+++ b/Rhino.Templates/content/CPPSkin/.template.config/template.json
@@ -18,7 +18,7 @@
       "type": "parameter",
       "description": "Version of Rhino",
       "datatype": "choice",
-      "defaultValue": "7",
+      "defaultValue": "8",
       "choices": [
         {
           "choice": "7",
@@ -26,7 +26,7 @@
         },
         {
           "choice": "8",
-          "description": "Version 8 (WIP)"
+          "description": "Version 8"
         }
       ]
     },

--- a/Rhino.Templates/content/CPPSkin/MySkin.1App.cpp
+++ b/Rhino.Templates/content/CPPSkin/MySkin.1App.cpp
@@ -12,7 +12,7 @@ RHINO_PLUG_IN_DECLARE
 // TODO: fill in the following developer declarations 
 // with your company information. When completed,
 // delete the following #error directive.
-// #error Developer declarations block is incomplete!
+#error Developer declarations block is incomplete!
 RHINO_PLUG_IN_DEVELOPER_ORGANIZATION( L"My Company Name" );
 RHINO_PLUG_IN_DEVELOPER_ADDRESS( L"123 Developer Street\r\nCity State 12345-6789" );
 RHINO_PLUG_IN_DEVELOPER_COUNTRY( L"My Country" );

--- a/Rhino.Templates/content/CPPSkin/MySkin.1App.cpp
+++ b/Rhino.Templates/content/CPPSkin/MySkin.1App.cpp
@@ -12,7 +12,7 @@ RHINO_PLUG_IN_DECLARE
 // TODO: fill in the following developer declarations 
 // with your company information. When completed,
 // delete the following #error directive.
-#error Developer declarations block is incomplete!
+// #error Developer declarations block is incomplete!
 RHINO_PLUG_IN_DEVELOPER_ORGANIZATION( L"My Company Name" );
 RHINO_PLUG_IN_DEVELOPER_ADDRESS( L"123 Developer Street\r\nCity State 12345-6789" );
 RHINO_PLUG_IN_DEVELOPER_COUNTRY( L"My Country" );

--- a/Rhino.Templates/content/CSCommand/MyCommand.1.cs
+++ b/Rhino.Templates/content/CSCommand/MyCommand.1.cs
@@ -11,7 +11,7 @@ namespace MyNamespace
             Instance = this;
         }
 
-        ///<summary>The only instance of the MyCommand command.</summary>
+        ///<summary>The only instance of this command.</summary>
         public static MyCommand__1 Instance { get; private set; }
 
         public override string EnglishName => "MyCommand.1";

--- a/Rhino.Templates/content/CSGrasshopper/.template.config/dotnetcli.host.json
+++ b/Rhino.Templates/content/CSGrasshopper/.template.config/dotnetcli.host.json
@@ -44,6 +44,14 @@
     "UseWinForms": {
       "longName": "include-winforms",
       "shortName": "wf"
+    },
+    "BuildYak": {
+      "longName": "build-yak",
+      "shortName": "yak"
+    },
+    "IncludeVSCode": {
+      "longName": "include-vscode-launch",
+      "shortName": "vscode"
     }
   }
 }

--- a/Rhino.Templates/content/CSGrasshopper/.template.config/template.json
+++ b/Rhino.Templates/content/CSGrasshopper/.template.config/template.json
@@ -27,7 +27,7 @@
             "type": "parameter",
             "description": "Version of Rhino",
             "datatype": "choice",
-            "defaultValue": "7",
+            "defaultValue": "8",
             "choices": [
                 {
                     "choice": "6",
@@ -39,18 +39,21 @@
                 },
                 {
                     "choice": "8",
-                    "description": "Version 8 (WIP)"
+                    "description": "Version 8"
                 }
             ]
         },
-        "RhinoLocation": {
+        "BuildYak": {
           "type": "parameter",
-          "description": "Location of Rhino.exe, usually C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
-          "replaces": "MyExecutablePath",
-          "forms": {
-            "global": [ "JsonStringEncode" ]
-          },
-          "defaultValue": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe"
+          "description": "Include target to build yak package(s) for your plugin",
+          "datatype": "bool",
+          "defaultValue": "false"
+        },
+        "IncludeVSCode": {
+          "type": "parameter",
+          "description": "Include tasks.json and launch.json to build/debug in VS Code",
+          "datatype": "bool",
+          "defaultValue": "true"
         },
         "AddonDisplayName": {
             "type": "parameter",
@@ -98,21 +101,21 @@
         
         "UseWpf": {
           "type": "parameter",
-          "description": "Enable to use WPF designer in VS (Windows only)",
+          "description": "Enable to use WPF (Windows only)",
           "datatype": "bool",
           "defaultValue": "false"
         },
         "UseWinForms": {
           "type": "parameter",
-          "description": "Enable to use Windows Forms designer in VS (Windows only)",
+          "description": "Enable the use of Windows Forms",
           "datatype": "bool",
-          "defaultValue": "false"
+          "defaultValue": "true"
         },
         "UseWindowsDesktop": {
           "type": "computed",
           "value": "UseWpf || UseWinForms"
         },
-
+    
         "HostIdentifier": {
             "type": "bind",
             "binding": "HostIdentifier"
@@ -126,16 +129,20 @@
       }    
     },
     "sources": [
-        {
-            "modifiers": [
-                {
-                    "condition": "ComponentClassName == 'MyGrasshopper__1Component'",
-                    "rename": {
-                        "MyGrasshopper__1Component.cs": "MyGrasshopper.1Component.cs"
-                    }
-                }
-            ]
-        }
+      {
+        "modifiers": [
+          {
+            "condition": "!IncludeVSCode",
+            "exclude": [ ".vscode/*.*" ]
+          },
+          {
+            "condition": "ComponentClassName == 'MyGrasshopper__1Component'",
+            "rename": {
+              "MyGrasshopper__1Component.cs": "MyGrasshopper.1Component.cs"
+            }
+          }
+        ]
+      }
     ],
     "primaryOutputs": [
         { "path": "MyGrasshopper.1.csproj" },

--- a/Rhino.Templates/content/CSGrasshopper/.vscode/launch.json
+++ b/Rhino.Templates/content/CSGrasshopper/.vscode/launch.json
@@ -1,0 +1,87 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Rhino 8",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "",
+      "osx": {
+        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros"
+      },
+      "windows": {
+        "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+        "targetArchitecture": "x86_64",
+      },
+      "args": [],
+      "env": {
+        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
+      },
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "internalConsole"
+    },
+//#if (RhinoVersion <= '7')
+    {
+      "name": "Launch Rhino 7 Mac",
+      "type": "rhino",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "/Applications/Rhino 7.app/Contents/MacOS/Rhinoceros",
+      "args": [],
+      "env": {
+        // "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net48/MyGrasshopper.1.rhp",
+        "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net48/MyGrasshopper.1.gha"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+    {
+      "name": "Launch Rhino 7 Windows",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
+      "targetArchitecture": "x86_64",
+      "args": [
+      ],
+      "env": {
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+//#endif
+//#if (RhinoVersion <= '6')
+    {
+      "name": "Launch Rhino 6 Mac",
+      "type": "rhino",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "/Applications/Rhinoceros.app/Contents/MacOS/Rhinoceros",
+      "args": [],
+      "env": {
+        // "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net45/MyGrasshopper.1.rhp",
+        "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net45/MyGrasshopper.1.gha"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+    {
+      "name": "Launch Rhino 6 Windows",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
+      "targetArchitecture": "x86_64",
+      "args": [
+      ],
+      "env": {
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+//#endif
+  ],
+  "compounds": []
+}

--- a/Rhino.Templates/content/CSGrasshopper/.vscode/launch.json
+++ b/Rhino.Templates/content/CSGrasshopper/.vscode/launch.json
@@ -2,19 +2,39 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch Rhino 8",
+      "name": "Rhino 8 - netcore",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "",
       "osx": {
-        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros"
+        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros",
+        "args": [
+          "-runscript=_Grasshopper"
+        ]
       },
       "windows": {
         "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
         "targetArchitecture": "x86_64",
+        "args": "/netcore /runscript=\"_Grasshopper\""
       },
-      "args": [],
+      "env": {
+        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
+      },
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "internalConsole"
+    },
+    {
+      "name": "Rhino 8 Windows - netfx",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "windows": {
+        "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+        "targetArchitecture": "x86_64",
+        "args": "/netfx /runscript=\"_Grasshopper\""
+      },
       "env": {
         "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
       },
@@ -24,12 +44,14 @@
     },
 //#if (RhinoVersion <= '7')
     {
-      "name": "Launch Rhino 7 Mac",
+      "name": "Rhino 7 Mac",
       "type": "rhino",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "/Applications/Rhino 7.app/Contents/MacOS/Rhinoceros",
-      "args": [],
+      "args": [
+        "-runscript=_Grasshopper"
+      ],
       "env": {
         // "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net48/MyGrasshopper.1.rhp",
         "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net48/MyGrasshopper.1.gha"
@@ -38,14 +60,13 @@
       "console": "internalConsole"
     },
     {
-      "name": "Launch Rhino 7 Windows",
+      "name": "Rhino 7 Windows",
       "type": "clr",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
       "targetArchitecture": "x86_64",
-      "args": [
-      ],
+      "args": "/runscript=\"_Grasshopper\"",
       "env": {
       },
       "cwd": "${workspaceFolder}",
@@ -54,12 +75,14 @@
 //#endif
 //#if (RhinoVersion <= '6')
     {
-      "name": "Launch Rhino 6 Mac",
+      "name": "Rhino 6 Mac",
       "type": "rhino",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "/Applications/Rhinoceros.app/Contents/MacOS/Rhinoceros",
-      "args": [],
+      "args": [
+        "-runscript=_Grasshopper"
+      ],
       "env": {
         // "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net45/MyGrasshopper.1.rhp",
         "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net45/MyGrasshopper.1.gha"
@@ -68,14 +91,13 @@
       "console": "internalConsole"
     },
     {
-      "name": "Launch Rhino 6 Windows",
+      "name": "Rhino 6 Windows",
       "type": "clr",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
       "targetArchitecture": "x86_64",
-      "args": [
-      ],
+      "args": "/runscript=\"_Grasshopper\"",
       "env": {
       },
       "cwd": "${workspaceFolder}",

--- a/Rhino.Templates/content/CSGrasshopper/.vscode/tasks.json
+++ b/Rhino.Templates/content/CSGrasshopper/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "build",
+        "-clp:NoSummary",
+        "${workspaceFolder}/MyGrasshopper.1.csproj"
+      ],
+      "problemMatcher": "$msCompile",
+      "presentation": {
+        "reveal": "always",
+        "clear": true
+      },
+      "group": "build"
+    }
+  ]
+}

--- a/Rhino.Templates/content/CSGrasshopper/MyGrasshopper.1.csproj
+++ b/Rhino.Templates/content/CSGrasshopper/MyGrasshopper.1.csproj
@@ -1,25 +1,119 @@
-﻿<!--#if (UseWindowsDesktop)-->
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-<!--#else-->
-<Project Sdk="Microsoft.NET.Sdk">
-<!--#endif-->
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	
   <PropertyGroup>
-    <TargetFramework Condition="$(RhinoVersion) == '6'">net45</TargetFramework>
-    <TargetFramework Condition="$(RhinoVersion) == '7'">net48</TargetFramework>
-    <TargetFrameworks Condition="$(RhinoVersion) == '8'">net7.0;net48</TargetFrameworks>
+    <!-- Select the framework(s) you wish to target.
+        Rhino 6: net45
+        Rhino 7: net48
+        Rhino 8 Windows: net48, net7.0, net7.0-windows, net7.0-windows10.0.22000.0, etc
+        Rhino 8 Mac: net7.0, net7.0-macos, net7.0-macos12.0, etc
+    -->
+<!--#if (RhinoVersion == '6')-->
+<!--#if (UseWpf)-->
+    <TargetFrameworks>net7.0-windows;net48;net45</TargetFrameworks>
+<!--#elif (UseWindowsDesktop)-->
+    <TargetFrameworks>net7.0-windows;net7.0;net48;net45</TargetFrameworks>
+<!--#else-->
+    <TargetFrameworks>net7.0;net48;net45</TargetFrameworks>
+<!--#endif-->
+<!--#endif-->
+<!--#if (RhinoVersion >= '7')-->
+<!--#if (UseWpf)-->
+    <TargetFrameworks>net7.0-windows;net48</TargetFrameworks>
+<!--#elif (UseWindowsDesktop)-->
+    <TargetFrameworks>net7.0-windows;net7.0;net48</TargetFrameworks>
+<!--#else-->
+    <TargetFrameworks>net7.0;net48</TargetFrameworks>
+<!--#endif-->
+<!--#endif-->
+    <EnableDynamicLoading>true</EnableDynamicLoading>
     <Version>1.0</Version>
     <Title>MyGrasshopper.1</Title>
     <Description>Description of MyGrasshopper.1</Description>
     <TargetExt>.gha</TargetExt>
-    <UseWpf Condition="$(UseWpf) == 'True'">true</UseWpf>
-    <UseWindowsForms Condition="$(UseWinForms) == 'True'">true</UseWindowsForms>
+<!--#if (UseWinForms)-->
+    <NoWarn>NU1701;NETSDK1086</NoWarn>
+<!--#else-->
+    <NoWarn>NU1701</NoWarn>
+<!--#endif-->
+    <EnableWindowsTargeting Condition="$(UseWindowsDesktop) == 'True'">true</EnableWindowsTargeting>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Grasshopper" Version="6.35.21222.17001" Condition="$(RhinoVersion) == '6'" IncludeAssets="compile;build" />
-    <PackageReference Include="Grasshopper" Version="7.13.21348.13001" Condition="$(RhinoVersion) == '7'" IncludeAssets="compile;build" />
-    <PackageReference Include="Grasshopper" Version="8.0.23164.14305-wip" Condition="$(RhinoVersion) == '8'" IncludeAssets="compile;build" />
+<!--#if (RhinoVersion <= '6')-->
+    <PackageReference Include="Grasshopper" Version="6.35.21222.17001" Condition="$(TargetFramework) == 'net45'" ExcludeAssets="runtime" />
+<!--#endif-->
+<!--#if (RhinoVersion <= '7')-->
+    <PackageReference Include="Grasshopper" Version="7.0.20314.3001" Condition="$(TargetFramework) == 'net48'" ExcludeAssets="runtime" />
+    <PackageReference Include="Grasshopper" Version="8.0.23304.9001" Condition="!$(TargetFramework.StartsWith('net4'))" ExcludeAssets="runtime" />
+<!--#endif-->
+<!--#if (RhinoVersion == '8')-->
+    <PackageReference Include="Grasshopper" Version="8.0.23304.9001" ExcludeAssets="runtime" />
+<!--#endif-->
+  </ItemGroup>
+  
+<!--#if (UseWindowsDesktop)-->
+  <!-- For Windows only builds -->
+  <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))">
+<!--#if (UseWinForms)-->
+    <UseWindowsForms>true</UseWindowsForms>
+<!--#endif-->
+<!--#if (UseWpf)-->
+    <UseWpf>true</UseWpf>
+<!--#endif-->
+  </PropertyGroup>
+
+<!--#endif-->
+<!--#if (UseWinForms)-->
+  <!-- Reference WinForms for .NET 7.0 on macOS -->
+  <ItemGroup Condition="!($(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4')))">
+    <!-- Rhino 8.11 and later you can use this -->
+    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
+    
+    <!-- Rhino 8.10 and earlier -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
+    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" ExcludeAssets="runtime" />
   </ItemGroup>
 
+<!--#endif-->
+<!--#if (RhinoVersion < '8')-->
+  <Target Name="CopyPdbForMonoDebugging" AfterTargets="AfterBuild">
+    <!-- Enable debugging in Rhino 6/7 on Mac -->
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFiles="$(TargetDir)$(TargetName).gha.pdb" Condition="$([MSBuild]::IsOSPlatform(OSX)) and $(TargetFramework.StartsWith('net4')) and Exists('$(TargetDir)$(TargetName).pdb')" />
+  </Target>
+
+<!--#endif-->
+<!--#if (BuildYak)-->
+  <Target Name="BuildYakPackage" AfterTargets="DispatchToInnerBuilds">
+    <PropertyGroup>
+      <YakExecutable Condition="$(YakExecutable) == '' and $([MSBuild]::IsOSPlatform(windows)) and Exists('C:\Program Files\Rhino 8\System\Yak.exe')">C:\Program Files\Rhino 8\System\Yak.exe</YakExecutable>
+      <YakExecutable Condition="$(YakExecutable) == '' and $([MSBuild]::IsOSPlatform(macos)) and Exists('/Applications/Rhino 8.app/Contents/Resources/bin/yak')">/Applications/Rhino 8.app/Contents/Resources/bin/yak</YakExecutable>
+      
+      <BuildYakPackage Condition="$(BuildYakPackage) == '' and $(YakExecutable) != '' and Exists($(YakExecutable))">True</BuildYakPackage>
+    </PropertyGroup>
+    
+    <Warning Text="Could not find Yak executable" Condition="$(YakExecutable) == ''" />
+
+    <ItemGroup>
+      <YakPackagesToDelete Include="$(OutputPath)\*.yak;$(OutputPath)\**\manifest.yml" />
+    </ItemGroup>
+    
+    <Delete Files="@(YakPackagesToDelete)" />
+
+    <Exec Command="&quot;$(YakExecutable)&quot; spec" WorkingDirectory="$(OutputPath)" Condition="$(BuildYakPackage) == 'True'" />
+    <Exec Command="&quot;$(YakExecutable)&quot; build" WorkingDirectory="$(OutputPath)" Condition="$(BuildYakPackage) == 'True'" />
+
+<!--#if (RhinoVersion <= '7')-->
+    <!-- Rhino 7 -->
+    <Exec Command="&quot;$(YakExecutable)&quot; spec" WorkingDirectory="$(OutputPath)net48\" Condition="$(BuildYakPackage) == 'True'" />
+    <Exec Command="&quot;$(YakExecutable)&quot; build" WorkingDirectory="$(OutputPath)net48\" Condition="$(BuildYakPackage) == 'True'" />
+    
+    <ItemGroup>
+      <YakPackageToMove Include="$(BaseOutputPath)$(Configuration)\net48\*.yak" />
+    </ItemGroup>
+    <Move SourceFiles="@(YakPackageToMove)" DestinationFolder="$(BaseOutputPath)$(Configuration)\" Condition="$(BuildYakPackage) == 'True'" />
+<!--#endif-->
+  </Target>
+
+<!--#endif-->
 </Project>

--- a/Rhino.Templates/content/CSGrasshopper/MyGrasshopper.1.csproj
+++ b/Rhino.Templates/content/CSGrasshopper/MyGrasshopper.1.csproj
@@ -26,9 +26,6 @@
 <!--#endif-->
 <!--#endif-->
     <EnableDynamicLoading>true</EnableDynamicLoading>
-    <Version>1.0</Version>
-    <Title>MyGrasshopper.1</Title>
-    <Description>Description of MyGrasshopper.1</Description>
     <TargetExt>.gha</TargetExt>
 <!--#if (UseWinForms)-->
     <NoWarn>NU1701;NETSDK1086</NoWarn>
@@ -36,6 +33,14 @@
     <NoWarn>NU1701</NoWarn>
 <!--#endif-->
     <EnableWindowsTargeting Condition="$(UseWindowsDesktop) == 'True'">true</EnableWindowsTargeting>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- Specifies information for Assembly and Yak -->
+    <Version>1.0</Version>
+    <Title>MyGrasshopper.1</Title>
+    <Company>MyGrasshopper.1 Authors</Company>
+    <Description>Description of MyGrasshopper.1</Description>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Rhino.Templates/content/CSGrasshopper/MyGrasshopper.1Info.cs
+++ b/Rhino.Templates/content/CSGrasshopper/MyGrasshopper.1Info.cs
@@ -22,5 +22,8 @@ namespace MyGrasshopper._1
 
     //Return a string representing your preferred contact details.
     public override string AuthorContact => "";
+
+    //Return a string representing the version.  This returns the same version as the assembly.
+    public override string AssemblyVersion => GetType().Assembly.GetName().Version.ToString();
   }
 }

--- a/Rhino.Templates/content/CSGrasshopper/Properties/launchSettings.json
+++ b/Rhino.Templates/content/CSGrasshopper/Properties/launchSettings.json
@@ -1,9 +1,34 @@
 {
   "profiles": {
-    "MyGrasshopper.1": {
+//#if (RhinoVersion <= '8')
+    "Rhino 8 netcore": {
       "commandName": "Executable",
-      "executablePath": "MyExecutablePath",
-      "commandLineArgs": ""
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netcore",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
+      }
+    },
+    "Rhino 8 netfx": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netfx",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
+      }
+    },
+//#endif
+//#if (RhinoVersion <= '7')
+    "Rhino 7": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe"
+    },
+//#endif
+//#if (RhinoVersion <= '6')
+    "Rhino 6": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe"
     }
+//#endif
   }
 }

--- a/Rhino.Templates/content/CSGrasshopper/Properties/launchSettings.json
+++ b/Rhino.Templates/content/CSGrasshopper/Properties/launchSettings.json
@@ -1,18 +1,18 @@
 {
   "profiles": {
 //#if (RhinoVersion <= '8')
-    "Rhino 8 netcore": {
+    "Rhino 8 - netcore": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
-      "commandLineArgs": "/netcore",
+      "commandLineArgs": "/netcore /runscript=\"_Grasshopper\"",
       "environmentVariables": {
         "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
       }
     },
-    "Rhino 8 netfx": {
+    "Rhino 8 - netfx": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
-      "commandLineArgs": "/netfx",
+      "commandLineArgs": "/netfx /runscript=\"_Grasshopper\"",
       "environmentVariables": {
         "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
       }
@@ -21,13 +21,15 @@
 //#if (RhinoVersion <= '7')
     "Rhino 7": {
       "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe"
+      "executablePath": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
+      "commandLineArgs": "/runscript=\"_Grasshopper\"",
     },
 //#endif
 //#if (RhinoVersion <= '6')
     "Rhino 6": {
       "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe"
+      "executablePath": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
+      "commandLineArgs": "/runscript=\"_Grasshopper\"",
     }
 //#endif
   }

--- a/Rhino.Templates/content/CSRhino/.template.config/dotnetcli.host.json
+++ b/Rhino.Templates/content/CSRhino/.template.config/dotnetcli.host.json
@@ -27,9 +27,6 @@
       "longName": "file-extension",
       "shortName": "ext"
     },
-    "RhinoLocation": {
-      "longName": "rhino-location"
-    },
     "UseWpf": {
       "longName": "include-wpf",
       "shortName": "wpf"
@@ -37,6 +34,14 @@
     "UseWinForms": {
       "longName": "include-winforms",
       "shortName": "wf"
+    },
+    "BuildYak": {
+      "longName": "build-yak",
+      "shortName": "yak"
+    },
+    "IncludeVSCode": {
+      "longName": "include-vscode-launch",
+      "shortName": "vscode"
     }
   }
 }

--- a/Rhino.Templates/content/CSRhino/.template.config/template.json
+++ b/Rhino.Templates/content/CSRhino/.template.config/template.json
@@ -53,7 +53,7 @@
       "type": "parameter",
       "description": "Version of Rhino",
       "datatype": "choice",
-      "defaultValue": "7",
+      "defaultValue": "8",
       "choices": [
         {
           "choice": "6",
@@ -65,18 +65,22 @@
         },
         {
           "choice": "8",
-          "description": "Version 8 (WIP)"
+          "description": "Version 8"
         }
-      ]
+      ],
+      "replaces": "MyRhinoVersion"
     },
-    "RhinoLocation": {
+    "BuildYak": {
       "type": "parameter",
-      "description": "Location of Rhino.exe, usually C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
-      "replaces": "MyExecutablePath",
-      "forms": {
-        "global": [ "JsonStringEncode" ]
-      },
-      "defaultValue": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe"
+      "description": "Include target to build yak package(s) for your plugin",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
+    "IncludeVSCode": {
+      "type": "parameter",
+      "description": "Include tasks.json and launch.json to build/debug in VS Code",
+      "datatype": "bool",
+      "defaultValue": "true"
     },
     "CommandClassName": {
       "type": "parameter",
@@ -157,6 +161,10 @@
   "sources": [
     {
       "modifiers": [
+        {
+          "condition": "!IncludeVSCode",
+          "exclude": [ ".vscode/*.*" ]
+        },
         {
           "condition": "PluginType != 'utility'",
           "exclude": [ "EmbeddedResources/plugin-utility.ico" ]

--- a/Rhino.Templates/content/CSRhino/.vscode/launch.json
+++ b/Rhino.Templates/content/CSRhino/.vscode/launch.json
@@ -2,19 +2,41 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch Rhino 8",
+      "name": "Rhino 8 - netcore",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "",
       "osx": {
-        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros"
+        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros",
+        "args": [],
       },
       "windows": {
         "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
         "targetArchitecture": "x86_64",
+        "args": [
+          "/netcore"
+        ]
       },
-      "args": [],
+      "env": {
+        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
+      },
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "internalConsole"
+    },
+    {
+      "name": "Rhino 8 Windows - netfx",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "windows": {
+        "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+        "targetArchitecture": "x86_64",
+        "args": [
+          "/netfx"
+        ]
+      },
       "env": {
         "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
       },
@@ -24,7 +46,7 @@
     },
 //#if (RhinoVersion <= '7')
     {
-      "name": "Launch Rhino 7 Mac",
+      "name": "Rhino 7 Mac",
       "type": "rhino",
       "request": "launch",
       "preLaunchTask": "build",
@@ -38,7 +60,7 @@
       "console": "internalConsole"
     },
     {
-      "name": "Launch Rhino 7 Windows",
+      "name": "Rhino 7 Windows",
       "type": "clr",
       "request": "launch",
       "preLaunchTask": "build",
@@ -55,7 +77,7 @@
 //#endif
 //#if (RhinoVersion <= '6')
     {
-      "name": "Launch Rhino 6 Mac",
+      "name": "Rhino 6 Mac",
       "type": "rhino",
       "request": "launch",
       "preLaunchTask": "build",
@@ -69,7 +91,7 @@
       "console": "internalConsole"
     },
     {
-      "name": "Launch Rhino 6 Windows",
+      "name": "Rhino 6 Windows",
       "type": "clr",
       "request": "launch",
       "preLaunchTask": "build",

--- a/Rhino.Templates/content/CSRhino/.vscode/launch.json
+++ b/Rhino.Templates/content/CSRhino/.vscode/launch.json
@@ -1,0 +1,89 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Rhino 8",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "",
+      "osx": {
+        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros"
+      },
+      "windows": {
+        "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+        "targetArchitecture": "x86_64",
+      },
+      "args": [],
+      "env": {
+        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
+      },
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "internalConsole"
+    },
+//#if (RhinoVersion <= '7')
+    {
+      "name": "Launch Rhino 7 Mac",
+      "type": "rhino",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "/Applications/Rhino 7.app/Contents/MacOS/Rhinoceros",
+      "args": [],
+      "env": {
+        "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net48/MyRhino.1.rhp",
+        // "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net48/MyRhino.1.gha"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+    {
+      "name": "Launch Rhino 7 Windows",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
+      "targetArchitecture": "x86_64",
+      "args": [
+        "${workspaceFolder}/bin/Debug/net48/MyRhino.1.rhp"
+      ],
+      "env": {
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+//#endif
+//#if (RhinoVersion <= '6')
+    {
+      "name": "Launch Rhino 6 Mac",
+      "type": "rhino",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "/Applications/Rhinoceros.app/Contents/MacOS/Rhinoceros",
+      "args": [],
+      "env": {
+        "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net45/MyRhino.1.rhp",
+        // "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net45/MyRhino.1.gha"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+    {
+      "name": "Launch Rhino 6 Windows",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
+      "targetArchitecture": "x86_64",
+      "args": [
+        "${workspaceFolder}/bin/Debug/net45/MyRhino.1.rhp"
+      ],
+      "env": {
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+//#endif
+  ],
+  "compounds": []
+}

--- a/Rhino.Templates/content/CSRhino/.vscode/tasks.json
+++ b/Rhino.Templates/content/CSRhino/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "build",
+        "-clp:NoSummary",
+        "${workspaceFolder}/MyRhino.1.csproj"
+      ],
+      "problemMatcher": "$msCompile",
+      "presentation": {
+        "reveal": "always",
+        "clear": true
+      },
+      "group": "build"
+    },
+    {
+      "label": "build release",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "build",
+        "-c:Release",
+        "-clp:NoSummary",
+        "${workspaceFolder}/MyRhino.1.csproj"
+      ],
+      "problemMatcher": "$msCompile",
+      "presentation": {
+        "reveal": "always",
+        "clear": true
+      },
+      "group": "build"
+    }
+  ]
+}

--- a/Rhino.Templates/content/CSRhino/MyRhino.1.csproj
+++ b/Rhino.Templates/content/CSRhino/MyRhino.1.csproj
@@ -26,9 +26,6 @@
 <!--#endif-->
 <!--#endif-->
     <EnableDynamicLoading>true</EnableDynamicLoading>
-    <Version>1.0</Version>
-    <Title>MyRhino.1</Title>
-    <Description>Description of MyRhino.1</Description>
     <TargetExt>.rhp</TargetExt>
 <!--#if (UseWinForms)-->
     <NoWarn>NU1701;NETSDK1086</NoWarn>
@@ -36,6 +33,14 @@
     <NoWarn>NU1701</NoWarn>
 <!--#endif-->
     <EnableWindowsTargeting Condition="$(UseWindowsDesktop) == 'True'">true</EnableWindowsTargeting>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- Specifies information for Assembly and Yak -->
+    <Version>1.0</Version>
+    <Title>MyRhino.1</Title>
+    <Company>MyRhino.1 Authors</Company>
+    <Description>Description of MyRhino.1</Description>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Rhino.Templates/content/CSRhino/MyRhino.1.csproj
+++ b/Rhino.Templates/content/CSRhino/MyRhino.1.csproj
@@ -1,29 +1,119 @@
-﻿<!--#if (UseWindowsDesktop)-->
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-<!--#else-->
-<Project Sdk="Microsoft.NET.Sdk">
-<!--#endif-->
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	
   <PropertyGroup>
-    <TargetFramework Condition="$(RhinoVersion) == '6'">net45</TargetFramework>
-    <TargetFramework Condition="$(RhinoVersion) == '7'">net48</TargetFramework>
-    <TargetFrameworks Condition="$(RhinoVersion) == '8'">net7.0;net48</TargetFrameworks>
+    <!-- Select the framework(s) you wish to target.
+        Rhino 6: net45
+        Rhino 7: net48
+        Rhino 8 Windows: net48, net7.0, net7.0-windows, net7.0-windows10.0.22000.0, etc
+        Rhino 8 Mac: net7.0, net7.0-macos, net7.0-macos12.0, etc
+    -->
+<!--#if (RhinoVersion == '6')-->
+<!--#if (UseWpf)-->
+    <TargetFrameworks>net7.0-windows;net48;net45</TargetFrameworks>
+<!--#elif (UseWindowsDesktop)-->
+    <TargetFrameworks>net7.0-windows;net7.0;net48;net45</TargetFrameworks>
+<!--#else-->
+    <TargetFrameworks>net7.0;net48;net45</TargetFrameworks>
+<!--#endif-->
+<!--#endif-->
+<!--#if (RhinoVersion >= '7')-->
+<!--#if (UseWpf)-->
+    <TargetFrameworks>net7.0-windows;net48</TargetFrameworks>
+<!--#elif (UseWindowsDesktop)-->
+    <TargetFrameworks>net7.0-windows;net7.0;net48</TargetFrameworks>
+<!--#else-->
+    <TargetFrameworks>net7.0;net48</TargetFrameworks>
+<!--#endif-->
+<!--#endif-->
+    <EnableDynamicLoading>true</EnableDynamicLoading>
     <Version>1.0</Version>
     <Title>MyRhino.1</Title>
     <Description>Description of MyRhino.1</Description>
     <TargetExt>.rhp</TargetExt>
-    <UseWpf Condition="$(UseWpf) == 'True'">true</UseWpf>
-    <UseWindowsForms Condition="$(UseWinForms) == 'True'">true</UseWindowsForms>
+<!--#if (UseWinForms)-->
+    <NoWarn>NU1701;NETSDK1086</NoWarn>
+<!--#else-->
+    <NoWarn>NU1701</NoWarn>
+<!--#endif-->
+    <EnableWindowsTargeting Condition="$(UseWindowsDesktop) == 'True'">true</EnableWindowsTargeting>
+  </PropertyGroup>
+  
+  <ItemGroup>
+<!--#if (RhinoVersion <= '6')-->
+    <PackageReference Include="Grasshopper" Version="6.35.21222.17001" Condition="$(TargetFramework) == 'net45'" ExcludeAssets="runtime" />
+<!--#endif-->
+<!--#if (RhinoVersion <= '7')-->
+    <PackageReference Include="Grasshopper" Version="7.0.20314.3001" Condition="$(TargetFramework) == 'net48'" ExcludeAssets="runtime" />
+    <PackageReference Include="Grasshopper" Version="8.0.23304.9001" Condition="!$(TargetFramework.StartsWith('net4'))" ExcludeAssets="runtime" />
+<!--#endif-->
+<!--#if (RhinoVersion == '8')-->
+    <PackageReference Include="Grasshopper" Version="8.0.23304.9001" ExcludeAssets="runtime" />
+<!--#endif-->
+  </ItemGroup>
+  
+<!--#if (UseWindowsDesktop)-->
+  <!-- For Windows only builds -->
+  <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))">
+<!--#if (UseWinForms)-->
+    <UseWindowsForms>true</UseWindowsForms>
+<!--#endif-->
+<!--#if (UseWpf)-->
+    <UseWpf>true</UseWpf>
+<!--#endif-->
   </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="EmbeddedResources\**\*" />
+<!--#endif-->
+<!--#if (UseWinForms)-->
+  <!-- Reference WinForms for .NET 7.0 on macOS -->
+  <ItemGroup Condition="!($(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4')))">
+    <!-- Rhino 8.11 and later you can use this -->
+    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
+    
+    <!-- Rhino 8.10 and earlier -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
+    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" ExcludeAssets="runtime" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="RhinoCommon" Version="6.35.21222.17001" Condition="$(RhinoVersion) == '6'" IncludeAssets="compile;build" />
-    <PackageReference Include="RhinoCommon" Version="7.13.21348.13001" Condition="$(RhinoVersion) == '7'" IncludeAssets="compile;build" />
-    <PackageReference Include="RhinoCommon" Version="8.0.23164.14305-wip" Condition="$(RhinoVersion) == '8'" IncludeAssets="compile;build" />
-  </ItemGroup>
-  
+
+<!--#endif-->
+<!--#if (RhinoVersion < '8')-->
+  <Target Name="CopyPdbForMonoDebugging" AfterTargets="AfterBuild">
+    <!-- Enable debugging in Rhino 6/7 on Mac -->
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFiles="$(TargetDir)$(TargetName).rhp.pdb" Condition="$([MSBuild]::IsOSPlatform(OSX)) and $(TargetFramework.StartsWith('net4')) and Exists('$(TargetDir)$(TargetName).pdb')" />
+  </Target>
+
+<!--#endif-->
+<!--#if (BuildYak)-->
+  <Target Name="BuildYakPackage" AfterTargets="DispatchToInnerBuilds">
+    <PropertyGroup>
+      <YakExecutable Condition="$(YakExecutable) == '' and $([MSBuild]::IsOSPlatform(windows)) and Exists('C:\Program Files\Rhino 8\System\Yak.exe')">C:\Program Files\Rhino 8\System\Yak.exe</YakExecutable>
+      <YakExecutable Condition="$(YakExecutable) == '' and $([MSBuild]::IsOSPlatform(macos)) and Exists('/Applications/Rhino 8.app/Contents/Resources/bin/yak')">/Applications/Rhino 8.app/Contents/Resources/bin/yak</YakExecutable>
+      
+      <BuildYakPackage Condition="$(BuildYakPackage) == '' and $(YakExecutable) != '' and Exists($(YakExecutable))">True</BuildYakPackage>
+    </PropertyGroup>
+    
+    <Warning Text="Could not find Yak executable" Condition="$(YakExecutable) == ''" />
+
+    <ItemGroup>
+      <YakPackagesToDelete Include="$(OutputPath)\*.yak;$(OutputPath)\**\manifest.yml" />
+    </ItemGroup>
+    
+    <Delete Files="@(YakPackagesToDelete)" />
+
+    <Exec Command="&quot;$(YakExecutable)&quot; spec" WorkingDirectory="$(OutputPath)" Condition="$(BuildYakPackage) == 'True'" />
+    <Exec Command="&quot;$(YakExecutable)&quot; build" WorkingDirectory="$(OutputPath)" Condition="$(BuildYakPackage) == 'True'" />
+
+<!--#if (RhinoVersion <= '7')-->
+    <!-- Rhino 7 -->
+    <Exec Command="&quot;$(YakExecutable)&quot; spec" WorkingDirectory="$(OutputPath)net48\" Condition="$(BuildYakPackage) == 'True'" />
+    <Exec Command="&quot;$(YakExecutable)&quot; build" WorkingDirectory="$(OutputPath)net48\" Condition="$(BuildYakPackage) == 'True'" />
+    
+    <ItemGroup>
+      <YakPackageToMove Include="$(BaseOutputPath)$(Configuration)\net48\*.yak" />
+    </ItemGroup>
+    <Move SourceFiles="@(YakPackageToMove)" DestinationFolder="$(BaseOutputPath)$(Configuration)\" Condition="$(BuildYakPackage) == 'True'" />
+<!--#endif-->
+  </Target>
+
+<!--#endif-->
 </Project>

--- a/Rhino.Templates/content/CSRhino/Properties/launchSettings.json
+++ b/Rhino.Templates/content/CSRhino/Properties/launchSettings.json
@@ -1,9 +1,36 @@
 {
   "profiles": {
-    "MyRhino.1": {
+//#if (RhinoVersion <= '8')
+    "Rhino 8 netcore": {
       "commandName": "Executable",
-      "executablePath": "MyExecutablePath",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netcore",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
+      }
+    },
+    "Rhino 8 netfx": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netfx",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
+      }
+    },
+//#endif
+//#if (RhinoVersion <= '7')
+    "Rhino 7": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
+      "commandLineArgs": "$(TargetPath)"
+    },
+//#endif
+//#if (RhinoVersion <= '6')
+    "Rhino 6": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
       "commandLineArgs": "$(TargetPath)"
     }
+//#endif
   }
 }

--- a/Rhino.Templates/content/CSRhino/Properties/launchSettings.json
+++ b/Rhino.Templates/content/CSRhino/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "profiles": {
 //#if (RhinoVersion <= '8')
-    "Rhino 8 netcore": {
+    "Rhino 8 - netcore": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
       "commandLineArgs": "/netcore",
@@ -9,7 +9,7 @@
         "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
       }
     },
-    "Rhino 8 netfx": {
+    "Rhino 8 - netfx": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
       "commandLineArgs": "/netfx",

--- a/Rhino.Templates/content/CSZooPlugIn/MyZooPlugin.1.csproj
+++ b/Rhino.Templates/content/CSZooPlugIn/MyZooPlugin.1.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="C:\Program Files (x86)\Zoo 7\ZooPlugin.dll" Private="False" />
+    <Reference Include="C:\Program Files (x86)\Zoo 8\ZooPlugin.dll" Private="False" />
   </ItemGroup>
 </Project>

--- a/Rhino.Templates/content/VBGrasshopper/.template.config/dotnetcli.host.json
+++ b/Rhino.Templates/content/VBGrasshopper/.template.config/dotnetcli.host.json
@@ -44,6 +44,14 @@
     "UseWinForms": {
       "longName": "include-winforms",
       "shortName": "wf"
+    },
+    "BuildYak": {
+      "longName": "build-yak",
+      "shortName": "yak"
+    },
+    "IncludeVSCode": {
+      "longName": "include-vscode-launch",
+      "shortName": "vscode"
     }
   }
 }

--- a/Rhino.Templates/content/VBGrasshopper/.template.config/template.json
+++ b/Rhino.Templates/content/VBGrasshopper/.template.config/template.json
@@ -1,165 +1,168 @@
 ﻿{
-    "$schema": "http://json.schemastore.org/template",
-    "author": "McNeel",
-    "classifications": [
-        "Rhino",
-        "Grasshopper"
-    ],
-    "name": "Grasshopper Assembly",
-    "description": "Build Grasshopper components for Rhino 3D in VB.NET",
-    "identity": "Grasshopper.Component.VB",
-    "groupIdentity": "Grasshopper.Component",
-    "shortName": "grasshopper",
-    "tags": {
-        "language": "VB",
-        "type": "project"
-    },
-    "sourceName": "MyGrasshopper.1",
-    "preferNameDirectory": true,
-    "symbols": {
-        "IncludeSample": {
-            "type": "parameter",
-            "description": "Include code sample.",
-            "dataType": "bool",
-            "defaultValue": "false"
-        },
-        "RhinoVersion": {
-            "type": "parameter",
-            "description": "Version of Rhino",
-            "datatype": "choice",
-            "defaultValue": "7",
-            "choices": [
-                {
-                    "choice": "6",
-                    "description": "Version 6"
-                },
-                {
-                    "choice": "7",
-                    "description": "Version 7"
-                },
-                {
-                    "choice": "8",
-                    "description": "Version 8 (WIP)"
-                }
-            ]
-        },
-        "RhinoLocation": {
+  "$schema": "http://json.schemastore.org/template",
+  "author": "McNeel",
+  "classifications": [
+      "Rhino",
+      "Grasshopper"
+  ],
+  "name": "Grasshopper Assembly",
+  "description": "Build Grasshopper components for Rhino 3D in VB.NET",
+  "identity": "Grasshopper.Component.VB",
+  "groupIdentity": "Grasshopper.Component",
+  "shortName": "grasshopper",
+  "tags": {
+      "language": "VB",
+      "type": "project"
+  },
+  "sourceName": "MyGrasshopper.1",
+  "preferNameDirectory": true,
+  "symbols": {
+      "IncludeSample": {
           "type": "parameter",
-          "description": "Location of Rhino.exe, usually C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
-          "replaces": "MyExecutablePath",
-          "forms": {
-            "global": [ "JsonStringEncode" ]
+          "description": "Include code sample.",
+          "dataType": "bool",
+          "defaultValue": "false"
+      },
+      "RhinoVersion": {
+          "type": "parameter",
+          "description": "Version of Rhino",
+          "datatype": "choice",
+          "defaultValue": "8",
+          "choices": [
+              {
+                  "choice": "6",
+                  "description": "Version 6"
+              },
+              {
+                  "choice": "7",
+                  "description": "Version 7"
+              },
+              {
+                  "choice": "8",
+                  "description": "Version 8"
+              }
+          ]
+      },
+      "BuildYak": {
+        "type": "parameter",
+        "description": "Include target to build yak package(s) for your plugin",
+        "datatype": "bool",
+        "defaultValue": "false"
+      },
+      "IncludeVSCode": {
+        "type": "parameter",
+        "description": "Include tasks.json and launch.json to build/debug in VS Code",
+        "datatype": "bool",
+        "defaultValue": "true"
+      },
+      "AddonDisplayName": {
+          "type": "parameter",
+          "description": "Display name of your Grasshopper assembly",
+          "datatype": "text",
+          "replaces": "MyGrasshopper.1 Info"
+      },
+      "ComponentClassName": {
+          "type": "parameter",
+          "description": "Name of the component class",
+          "datatype": "text",
+          "replaces": "MyGrasshopper__1Component",
+          "fileRename": "MyGrasshopper__1Component"
+      },
+      "ComponentName": {
+          "type": "parameter",
+          "description": "Display name of the component",
+          "datatype": "text",
+          "replaces": "MyGrasshopper.1 Component"
+      },
+      "ComponentNickname": {
+          "type": "parameter",
+          "description": "Nickname for the component",
+          "replaces": "ComponentNickname",
+          "defaultValue": "Nickname"
+      },
+      "ComponentDescription": {
+          "type": "parameter",
+          "description": "Description of the component",
+          "replaces": "ComponentDescription",
+          "defaultValue": "Description of component"
+      },
+      "ComponentCategory": {
+          "type": "parameter",
+          "description": "Category of the component",
+          "replaces": "ComponentCategory",
+          "defaultValue": "Category"
+      },
+      "ComponentSubcategory": {
+          "type": "parameter",
+          "description": "Subcategory of the component",
+          "replaces": "ComponentSubcategory",
+          "defaultValue": "Subcategory"
+      },
+      
+      "UseWpf": {
+        "type": "parameter",
+        "description": "Enable to use WPF (Windows only)",
+        "datatype": "bool",
+        "defaultValue": "false"
+      },
+      "UseWinForms": {
+        "type": "parameter",
+        "description": "Enable the use of Windows Forms",
+        "datatype": "bool",
+        "defaultValue": "true"
+      },
+      "UseWindowsDesktop": {
+        "type": "computed",
+        "value": "UseWpf || UseWinForms"
+      },
+  
+      "HostIdentifier": {
+          "type": "bind",
+          "binding": "HostIdentifier"
+      }
+  },
+  "forms": {
+    "JsonStringEncode": {
+      "identifier": "replace",
+      "pattern": "\\\\",      
+      "replacement": "\\\\"  
+    }    
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "!IncludeVSCode",
+          "exclude": [ ".vscode/*.*" ]
+        },
+        {
+          "condition": "ComponentClassName == 'MyGrasshopper__1Component'",
+          "rename": {
+            "MyGrasshopper__1Component.vb": "MyGrasshopper.1Component.vb"
+          }
+        }
+      ]
+    }
+  ],
+  "primaryOutputs": [
+      { "path": "MyGrasshopper.1.vbproj" },
+      { "path": "MyGrasshopper__1Component.vb" }
+  ],
+  "guids": [
+      "ee4e2b39-d96b-4e4c-8f9d-9b6561e61b64",
+      "e79cd2b5-cb9c-4d08-93ec-446cc1f6d923",
+      "cd826b9b-8dbe-4c31-aac1-6fc7ea2bcfb7"
+  ],
+  "postActions": [
+      {
+          "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+          "description": "Opens the command in the editor",
+          "manualInstructions": [],
+          "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+          "args": {
+              "files": "1"
           },
-          "defaultValue": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe"
-        },
-        "AddonDisplayName": {
-            "type": "parameter",
-            "description": "Display name of your Grasshopper assembly",
-            "datatype": "text",
-            "replaces": "MyGrasshopper.1 Info"
-        },
-        "ComponentClassName": {
-            "type": "parameter",
-            "description": "Name of the component class",
-            "datatype": "text",
-            "replaces": "MyGrasshopper__1Component",
-            "fileRename": "MyGrasshopper__1Component"
-        },
-        "ComponentName": {
-            "type": "parameter",
-            "description": "Display name of the component",
-            "datatype": "text",
-            "replaces": "MyGrasshopper.1 Component"
-        },
-        "ComponentNickname": {
-            "type": "parameter",
-            "description": "Nickname for the component",
-            "replaces": "ComponentNickname",
-            "defaultValue": "Nickname"
-        },
-        "ComponentDescription": {
-            "type": "parameter",
-            "description": "Description of the component",
-            "replaces": "ComponentDescription",
-            "defaultValue": "Description of component"
-        },
-        "ComponentCategory": {
-            "type": "parameter",
-            "description": "Category of the component",
-            "replaces": "ComponentCategory",
-            "defaultValue": "Category"
-        },
-        "ComponentSubcategory": {
-            "type": "parameter",
-            "description": "Subcategory of the component",
-            "replaces": "ComponentSubcategory",
-            "defaultValue": "Subcategory"
-        },
-        
-        "UseWpf": {
-          "type": "parameter",
-          "description": "Enable to use WPF designer in VS (Windows only)",
-          "datatype": "bool",
-          "defaultValue": "false"
-        },
-        "UseWinForms": {
-          "type": "parameter",
-          "description": "Enable to use Windows Forms designer in VS (Windows only)",
-          "datatype": "bool",
-          "defaultValue": "false"
-        },
-        "UseWindowsDesktop": {
-          "type": "computed",
-          "value": "UseWpf || UseWinForms"
-        },
-        
-        "HostIdentifier": {
-            "type": "bind",
-            "binding": "HostIdentifier"
-        }
-    },
-    "forms": {
-      "JsonStringEncode": {
-        "identifier": "replace",
-        "pattern": "\\\\",      
-        "replacement": "\\\\"  
-      }    
-    },
-    "sources": [
-        {
-            "modifiers": [
-                {
-                    "condition": "ComponentClassName == 'MyGrasshopper__1Component'",
-                    "rename": {
-                        "MyGrasshopper__1Component.vb": "MyGrasshopper.1Component.vb"
-                    }
-                }
-            ]
-        }
-    ],
-    "primaryOutputs": [
-        {
-            "path": "MyGrasshopper.1.vbproj"
-        },
-        {
-            "path": "MyGrasshopper__1Component.vb"
-        }
-    ],
-    "guids": [
-        "ee4e2b39-d96b-4e4c-8f9d-9b6561e61b64",
-        "e79cd2b5-cb9c-4d08-93ec-446cc1f6d923",
-        "cd826b9b-8dbe-4c31-aac1-6fc7ea2bcfb7"
-    ],
-    "postActions": [
-        {
-            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-            "description": "Opens the command in the editor",
-            "manualInstructions": [],
-            "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-            "args": {
-                "files": "1"
-            },
-            "continueOnError": true
-        }
-    ]
+          "continueOnError": true
+      }
+  ]
 }

--- a/Rhino.Templates/content/VBGrasshopper/.vscode/launch.json
+++ b/Rhino.Templates/content/VBGrasshopper/.vscode/launch.json
@@ -1,0 +1,87 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Rhino 8",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "",
+      "osx": {
+        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros"
+      },
+      "windows": {
+        "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+        "targetArchitecture": "x86_64",
+      },
+      "args": [],
+      "env": {
+        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
+      },
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "internalConsole"
+    },
+//#if (RhinoVersion <= '7')
+    {
+      "name": "Launch Rhino 7 Mac",
+      "type": "rhino",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "/Applications/Rhino 7.app/Contents/MacOS/Rhinoceros",
+      "args": [],
+      "env": {
+        // "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net48/MyGrasshopper.1.rhp",
+        "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net48/MyGrasshopper.1.gha"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+    {
+      "name": "Launch Rhino 7 Windows",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
+      "targetArchitecture": "x86_64",
+      "args": [
+      ],
+      "env": {
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+//#endif
+//#if (RhinoVersion <= '6')
+    {
+      "name": "Launch Rhino 6 Mac",
+      "type": "rhino",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "/Applications/Rhinoceros.app/Contents/MacOS/Rhinoceros",
+      "args": [],
+      "env": {
+        // "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net45/MyGrasshopper.1.rhp",
+        "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net45/MyGrasshopper.1.gha"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+    {
+      "name": "Launch Rhino 6 Windows",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
+      "targetArchitecture": "x86_64",
+      "args": [
+      ],
+      "env": {
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+//#endif
+  ],
+  "compounds": []
+}

--- a/Rhino.Templates/content/VBGrasshopper/.vscode/launch.json
+++ b/Rhino.Templates/content/VBGrasshopper/.vscode/launch.json
@@ -2,19 +2,39 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch Rhino 8",
+      "name": "Rhino 8 - netcore",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "",
       "osx": {
-        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros"
+        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros",
+        "args": [
+          "-runscript=_Grasshopper"
+        ]
       },
       "windows": {
         "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
         "targetArchitecture": "x86_64",
+        "args": "/netcore /runscript=\"_Grasshopper\""
       },
-      "args": [],
+      "env": {
+        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
+      },
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "internalConsole"
+    },
+    {
+      "name": "Rhino 8 Windows - netfx",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "windows": {
+        "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+        "targetArchitecture": "x86_64",
+        "args": "/netfx /runscript=\"_Grasshopper\""
+      },
       "env": {
         "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
       },
@@ -24,12 +44,14 @@
     },
 //#if (RhinoVersion <= '7')
     {
-      "name": "Launch Rhino 7 Mac",
+      "name": "Rhino 7 Mac",
       "type": "rhino",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "/Applications/Rhino 7.app/Contents/MacOS/Rhinoceros",
-      "args": [],
+      "args": [
+        "-runscript=_Grasshopper"
+      ],
       "env": {
         // "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net48/MyGrasshopper.1.rhp",
         "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net48/MyGrasshopper.1.gha"
@@ -38,14 +60,13 @@
       "console": "internalConsole"
     },
     {
-      "name": "Launch Rhino 7 Windows",
+      "name": "Rhino 7 Windows",
       "type": "clr",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
       "targetArchitecture": "x86_64",
-      "args": [
-      ],
+      "args": "/runscript=\"_Grasshopper\"",
       "env": {
       },
       "cwd": "${workspaceFolder}",
@@ -54,12 +75,14 @@
 //#endif
 //#if (RhinoVersion <= '6')
     {
-      "name": "Launch Rhino 6 Mac",
+      "name": "Rhino 6 Mac",
       "type": "rhino",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "/Applications/Rhinoceros.app/Contents/MacOS/Rhinoceros",
-      "args": [],
+      "args": [
+        "-runscript=_Grasshopper"
+      ],
       "env": {
         // "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net45/MyGrasshopper.1.rhp",
         "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net45/MyGrasshopper.1.gha"
@@ -68,14 +91,13 @@
       "console": "internalConsole"
     },
     {
-      "name": "Launch Rhino 6 Windows",
+      "name": "Rhino 6 Windows",
       "type": "clr",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
       "targetArchitecture": "x86_64",
-      "args": [
-      ],
+      "args": "/runscript=\"_Grasshopper\"",
       "env": {
       },
       "cwd": "${workspaceFolder}",

--- a/Rhino.Templates/content/VBGrasshopper/.vscode/tasks.json
+++ b/Rhino.Templates/content/VBGrasshopper/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "build",
+        "-clp:NoSummary",
+        "${workspaceFolder}/MyGrasshopper.1.vbproj"
+      ],
+      "problemMatcher": "$msCompile",
+      "presentation": {
+        "reveal": "always",
+        "clear": true
+      },
+      "group": "build"
+    }
+  ]
+}

--- a/Rhino.Templates/content/VBGrasshopper/MyGrasshopper.1.vbproj
+++ b/Rhino.Templates/content/VBGrasshopper/MyGrasshopper.1.vbproj
@@ -26,15 +26,20 @@
 <!--#endif-->
 <!--#endif-->
     <EnableDynamicLoading>true</EnableDynamicLoading>
-    <Version>1.0</Version>
-    <Title>MyGrasshopper.1</Title>
-    <Description>Description of MyGrasshopper.1</Description>
 <!--#if (UseWinForms)-->
     <NoWarn>NU1701;NETSDK1086</NoWarn>
 <!--#else-->
     <NoWarn>NU1701</NoWarn>
 <!--#endif-->
     <EnableWindowsTargeting Condition="$(UseWindowsDesktop) == 'True'">true</EnableWindowsTargeting>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Specifies information for Assembly and Yak -->
+    <Version>1.0</Version>
+    <Title>MyGrasshopper.1</Title>
+    <Company>MyGrasshopper.1 Authors</Company>
+    <Description>Description of MyGrasshopper.1</Description>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Rhino.Templates/content/VBGrasshopper/MyGrasshopper.1.vbproj
+++ b/Rhino.Templates/content/VBGrasshopper/MyGrasshopper.1.vbproj
@@ -1,30 +1,119 @@
-﻿<!--#if (UseWindowsDesktop)-->
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-<!--#else-->
-<Project Sdk="Microsoft.NET.Sdk">
-<!--#endif-->
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	
   <PropertyGroup>
-    <TargetFramework Condition="$(RhinoVersion) == '6'">net45</TargetFramework>
-    <TargetFramework Condition="$(RhinoVersion) == '7'">net48</TargetFramework>
-    <TargetFrameworks Condition="$(RhinoVersion) == '8'">net7.0;net48</TargetFrameworks>
+    <!-- Select the framework(s) you wish to target.
+        Rhino 6: net45
+        Rhino 7: net48
+        Rhino 8 Windows: net48, net7.0, net7.0-windows, net7.0-windows10.0.22000.0, etc
+        Rhino 8 Mac: net7.0, net7.0-macos, net7.0-macos12.0, etc
+    -->
+<!--#if (RhinoVersion == '6')-->
+<!--#if (UseWpf)-->
+    <TargetFrameworks>net7.0-windows;net48;net45</TargetFrameworks>
+<!--#elif (UseWindowsDesktop)-->
+    <TargetFrameworks>net7.0-windows;net7.0;net48;net45</TargetFrameworks>
+<!--#else-->
+    <TargetFrameworks>net7.0;net48;net45</TargetFrameworks>
+<!--#endif-->
+<!--#endif-->
+<!--#if (RhinoVersion >= '7')-->
+<!--#if (UseWpf)-->
+    <TargetFrameworks>net7.0-windows;net48</TargetFrameworks>
+<!--#elif (UseWindowsDesktop)-->
+    <TargetFrameworks>net7.0-windows;net7.0;net48</TargetFrameworks>
+<!--#else-->
+    <TargetFrameworks>net7.0;net48</TargetFrameworks>
+<!--#endif-->
+<!--#endif-->
+    <EnableDynamicLoading>true</EnableDynamicLoading>
     <Version>1.0</Version>
-    <AssemblyTitle>MyGrasshopper.1</AssemblyTitle>
+    <Title>MyGrasshopper.1</Title>
     <Description>Description of MyGrasshopper.1</Description>
-    <UseWpf Condition="$(UseWpf) == 'True'">true</UseWpf>
-    <UseWindowsForms Condition="$(UseWinForms) == 'True'">true</UseWindowsForms>
+<!--#if (UseWinForms)-->
+    <NoWarn>NU1701;NETSDK1086</NoWarn>
+<!--#else-->
+    <NoWarn>NU1701</NoWarn>
+<!--#endif-->
+    <EnableWindowsTargeting Condition="$(UseWindowsDesktop) == 'True'">true</EnableWindowsTargeting>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NetFramework.ReferenceAssemblies" Version="1.0.0" />
-    <PackageReference Include="Grasshopper" Version="6.35.21222.17001" Condition="$(RhinoVersion) == '6'" IncludeAssets="compile;build" />
-    <PackageReference Include="Grasshopper" Version="7.13.21348.13001" Condition="$(RhinoVersion) == '7'" IncludeAssets="compile;build" />
-    <PackageReference Include="Grasshopper" Version="8.0.23164.14305-wip" Condition="$(RhinoVersion) == '8'" IncludeAssets="compile;build" />
+<!--#if (RhinoVersion <= '6')-->
+    <PackageReference Include="Grasshopper" Version="6.35.21222.17001" Condition="$(TargetFramework) == 'net45'" ExcludeAssets="runtime" />
+<!--#endif-->
+<!--#if (RhinoVersion <= '7')-->
+    <PackageReference Include="Grasshopper" Version="7.0.20314.3001" Condition="$(TargetFramework) == 'net48'" ExcludeAssets="runtime" />
+    <PackageReference Include="Grasshopper" Version="8.0.23304.9001" Condition="!$(TargetFramework.StartsWith('net4'))" ExcludeAssets="runtime" />
+<!--#endif-->
+<!--#if (RhinoVersion == '8')-->
+    <PackageReference Include="Grasshopper" Version="8.0.23304.9001" ExcludeAssets="runtime" />
+<!--#endif-->
   </ItemGroup>
   
+<!--#if (UseWindowsDesktop)-->
+  <!-- For Windows only builds -->
+  <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))">
+<!--#if (UseWinForms)-->
+    <UseWindowsForms>true</UseWindowsForms>
+<!--#endif-->
+<!--#if (UseWpf)-->
+    <UseWpf>true</UseWpf>
+<!--#endif-->
+  </PropertyGroup>
+
+<!--#endif-->
+<!--#if (UseWinForms)-->
+  <!-- Reference WinForms for .NET 7.0 on macOS -->
+  <ItemGroup Condition="!($(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4')))">
+    <!-- Rhino 8.11 and later you can use this -->
+    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
+    
+    <!-- Rhino 8.10 and earlier -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
+    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" ExcludeAssets="runtime" />
+  </ItemGroup>
+
+<!--#endif-->
   <Target Name="RenameAssembly" AfterTargets="AfterBuild">
-      <Move SourceFiles="$(TargetPath)" DestinationFiles="$(TargetDir)$(TargetName).gha" />
-      <Move SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFiles="$(TargetDir)$(TargetName).gha.pdb" Condition="$([MSBuild]::IsOSPlatform(OSX))" />
+    <Move SourceFiles="$(TargetPath)" DestinationFiles="$(TargetDir)$(TargetName).gha" />
+<!--#if (RhinoVersion < '8')-->
+    <!-- Enable debugging in Rhino 6/7 on Mac -->
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFiles="$(TargetDir)$(TargetName).gha.pdb" Condition="$([MSBuild]::IsOSPlatform(OSX)) and $(TargetFramework.StartsWith('net4')) and Exists('$(TargetDir)$(TargetName).pdb')" />
+<!--#endif-->
   </Target>
 
+<!--#if (BuildYak)-->
+  <Target Name="BuildYakPackage" AfterTargets="DispatchToInnerBuilds">
+    <PropertyGroup>
+      <YakExecutable Condition="$(YakExecutable) == '' and $([MSBuild]::IsOSPlatform(windows)) and Exists('C:\Program Files\Rhino 8\System\Yak.exe')">C:\Program Files\Rhino 8\System\Yak.exe</YakExecutable>
+      <YakExecutable Condition="$(YakExecutable) == '' and $([MSBuild]::IsOSPlatform(macos)) and Exists('/Applications/Rhino 8.app/Contents/Resources/bin/yak')">/Applications/Rhino 8.app/Contents/Resources/bin/yak</YakExecutable>
+      
+      <BuildYakPackage Condition="$(BuildYakPackage) == '' and $(YakExecutable) != '' and Exists($(YakExecutable))">True</BuildYakPackage>
+    </PropertyGroup>
+    
+    <Warning Text="Could not find Yak executable" Condition="$(YakExecutable) == ''" />
+
+    <ItemGroup>
+      <YakPackagesToDelete Include="$(OutputPath)\*.yak;$(OutputPath)\**\manifest.yml" />
+    </ItemGroup>
+    
+    <Delete Files="@(YakPackagesToDelete)" />
+
+    <Exec Command="&quot;$(YakExecutable)&quot; spec" WorkingDirectory="$(OutputPath)" Condition="$(BuildYakPackage) == 'True'" />
+    <Exec Command="&quot;$(YakExecutable)&quot; build" WorkingDirectory="$(OutputPath)" Condition="$(BuildYakPackage) == 'True'" />
+
+<!--#if (RhinoVersion <= '7')-->
+    <!-- Rhino 7 -->
+    <Exec Command="&quot;$(YakExecutable)&quot; spec" WorkingDirectory="$(OutputPath)net48\" Condition="$(BuildYakPackage) == 'True'" />
+    <Exec Command="&quot;$(YakExecutable)&quot; build" WorkingDirectory="$(OutputPath)net48\" Condition="$(BuildYakPackage) == 'True'" />
+    
+    <ItemGroup>
+      <YakPackageToMove Include="$(BaseOutputPath)$(Configuration)\net48\*.yak" />
+    </ItemGroup>
+    <Move SourceFiles="@(YakPackageToMove)" DestinationFolder="$(BaseOutputPath)$(Configuration)\" Condition="$(BuildYakPackage) == 'True'" />
+<!--#endif-->
+  </Target>
+
+<!--#endif-->
 </Project>

--- a/Rhino.Templates/content/VBGrasshopper/MyGrasshopper.1Info.vb
+++ b/Rhino.Templates/content/VBGrasshopper/MyGrasshopper.1Info.vb
@@ -23,20 +23,27 @@ Public Class MyGrasshopper__1Info
 	End Property
 	Public Overrides ReadOnly Property Id As System.Guid
 		Get
-      Return New System.Guid("cd826b9b-8dbe-4c31-aac1-6fc7ea2bcfb7")
+			Return New System.Guid("cd826b9b-8dbe-4c31-aac1-6fc7ea2bcfb7")
 		End Get
 	End Property
 
 	Public Overrides ReadOnly Property AuthorName As String
 		Get
 			'Return a string identifying you or your company.
-      Return ""
+			Return ""
 		End Get
 	End Property
 	Public Overrides ReadOnly Property AuthorContact As String
 		Get
 			'Return a string representing your preferred contact details.
-      Return ""
+			Return ""
+		End Get
+	End Property
+	Public Overrides ReadOnly Property AssemblyVersion As String
+		Get
+			'Return a string representing the version.  This returns the same version as the assembly.
+			Return [GetType]().Assembly.GetName().Version.ToString()
 		End Get
 	End Property
 End Class
+

--- a/Rhino.Templates/content/VBGrasshopper/Properties/launchSettings.json
+++ b/Rhino.Templates/content/VBGrasshopper/Properties/launchSettings.json
@@ -1,9 +1,34 @@
 {
   "profiles": {
-    "MyGrasshopper.1": {
+//#if (RhinoVersion <= '8')
+    "Rhino 8 netcore": {
       "commandName": "Executable",
-      "executablePath": "MyExecutablePath",
-      "commandLineArgs": ""
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netcore",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
+      }
+    },
+    "Rhino 8 netfx": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netfx",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
+      }
+    },
+//#endif
+//#if (RhinoVersion <= '7')
+    "Rhino 7": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe"
+    },
+//#endif
+//#if (RhinoVersion <= '6')
+    "Rhino 6": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe"
     }
+//#endif
   }
 }

--- a/Rhino.Templates/content/VBGrasshopper/Properties/launchSettings.json
+++ b/Rhino.Templates/content/VBGrasshopper/Properties/launchSettings.json
@@ -1,18 +1,18 @@
 {
   "profiles": {
 //#if (RhinoVersion <= '8')
-    "Rhino 8 netcore": {
+    "Rhino 8 - netcore": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
-      "commandLineArgs": "/netcore",
+      "commandLineArgs": "/netcore /runscript=\"_Grasshopper\"",
       "environmentVariables": {
         "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
       }
     },
-    "Rhino 8 netfx": {
+    "Rhino 8 - netfx": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
-      "commandLineArgs": "/netfx",
+      "commandLineArgs": "/netfx /runscript=\"_Grasshopper\"",
       "environmentVariables": {
         "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
       }
@@ -21,13 +21,15 @@
 //#if (RhinoVersion <= '7')
     "Rhino 7": {
       "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe"
+      "executablePath": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
+      "commandLineArgs": "/runscript=\"_Grasshopper\"",
     },
 //#endif
 //#if (RhinoVersion <= '6')
     "Rhino 6": {
       "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe"
+      "executablePath": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
+      "commandLineArgs": "/runscript=\"_Grasshopper\"",
     }
 //#endif
   }

--- a/Rhino.Templates/content/VBRhino/.template.config/dotnetcli.host.json
+++ b/Rhino.Templates/content/VBRhino/.template.config/dotnetcli.host.json
@@ -27,9 +27,6 @@
       "longName": "file-extension",
       "shortName": "ext"
     },
-    "RhinoLocation": {
-      "longName": "rhino-location"
-    },
     "UseWpf": {
       "longName": "include-wpf",
       "shortName": "wpf"
@@ -37,6 +34,10 @@
     "UseWinForms": {
       "longName": "include-winforms",
       "shortName": "wf"
+    },
+    "BuildYak": {
+      "longName": "build-yak",
+      "shortName": "yak"
     }
   }
 }

--- a/Rhino.Templates/content/VBRhino/.template.config/template.json
+++ b/Rhino.Templates/content/VBRhino/.template.config/template.json
@@ -1,214 +1,222 @@
 ﻿{
-    "$schema": "http://json.schemastore.org/template",
-    "author": "McNeel",
-    "classifications": [ "Rhino", "RhinoCommon" ],
-    "name": "Rhino 3D Plug-In",
-    "description": "Build plug-ins for Rhino 3D with RhinoCommon in VB.NET",
-    "identity": "Rhino.Plugin.VB",
-    "groupIdentity": "Rhino.Plugin",
-    "shortName": "rhino",
-    "tags": {
-        "language": "VB",
-        "type": "project"
+  "$schema": "http://json.schemastore.org/template",
+  "author": "McNeel",
+  "classifications": [ "Rhino", "RhinoCommon" ],
+  "name": "Rhino 3D Plug-In",
+  "description": "Build plug-ins for Rhino 3D with RhinoCommon in VB.NET",
+  "identity": "Rhino.Plugin.VB",
+  "groupIdentity": "Rhino.Plugin",
+  "shortName": "rhino",
+  "tags": {
+    "language": "VB",
+    "type": "project"
+  },
+  "sourceName": "MyRhino.1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "PluginType": {
+      "type": "parameter",
+      "datatype": "choice",
+      "description": "Type of plugin to create",
+      "defaultValue": "utility",
+      "replaces": "utility",
+      "choices": [
+        {
+          "choice": "utility",
+          "description": "A generic utility plug-in"
+        },
+        {
+          "choice": "digitize",
+          "description": "A digitizer plug-in"
+        },
+        {
+          "choice": "render",
+          "description": "A rendering plug-in"
+        },
+        {
+          "choice": "import",
+          "description": "A file import plug-in"
+        },
+        {
+          "choice": "export",
+          "description": "A file export plug-in"
+        }
+      ]
     },
-    "sourceName": "MyRhino.1",
-    "preferNameDirectory": true,
-    "symbols": {
-        "PluginType": {
-            "type": "parameter",
-            "datatype": "choice",
-            "description": "Type of plugin to create",
-            "defaultValue": "utility",
-            "replaces": "utility",
-            "choices": [
-                {
-                    "choice": "utility",
-                    "description": "A generic utility plug-in"
-                },
-                {
-                    "choice": "digitize",
-                    "description": "A digitizer plug-in"
-                },
-                {
-                    "choice": "render",
-                    "description": "A rendering plug-in"
-                },
-                {
-                    "choice": "import",
-                    "description": "A file import plug-in"
-                },
-                {
-                    "choice": "export",
-                    "description": "A file export plug-in"
-                }
-            ]
+    "IncludeSample": {
+      "type": "parameter",
+      "description": "Include code sample (for utility plugins only).",
+      "dataType": "bool",
+      "defaultValue": "false"
+    },
+    "RhinoVersion": {
+      "type": "parameter",
+      "description": "Version of Rhino",
+      "datatype": "choice",
+      "defaultValue": "8",
+      "choices": [
+        {
+          "choice": "6",
+          "description": "Version 6"
         },
-        "IncludeSample": {
-            "type": "parameter",
-            "description": "Include code sample (for utility plugins only).",
-            "dataType": "bool",
-            "defaultValue": "false"
+        {
+          "choice": "7",
+          "description": "Version 7"
         },
-        "RhinoVersion": {
-            "type": "parameter",
-            "description": "Version of Rhino",
-            "datatype": "choice",
-            "defaultValue": "7",
-            "choices": [
-                {
-                    "choice": "6",
-                    "description": "Version 6"
-                },
-                {
-                    "choice": "7",
-                    "description": "Version 7"
-                },
-                {
-                    "choice": "8",
-                    "description": "Version 8 (WIP)"
-                }
-            ]
-        },
-        "RhinoLocation": {
-          "type": "parameter",
-          "description": "Location of Rhino.exe, usually C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
-          "replaces": "MyExecutablePath",
-          "forms": {
-            "global": [ "JsonStringEncode" ]
-          },
-          "defaultValue": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe"
-        },
-        "CommandClassName": {
-            "type": "parameter",
-            "description": "Name of the command class.",
-            "datatype": "text",
-            "replaces": "MyRhino__1Command",
-            "fileRename": "MyRhino__1Command"
-        },
-        "PluginClassName": {
-            "type": "parameter",
-            "description": "Name of the plugin class.",
-            "datatype": "text",
-            "replaces": "MyRhino__1Plugin",
-            "fileRename": "MyRhino__1Plugin"
-        },
-        "FileExtension": {
-            "type": "parameter",
-            "description": "Extension for file import/export plugin types (e.g. 'myext')",
-            "datatype": "text",
-            "replaces": "myext"
-        },
-        "FileDescription": {
-            "type": "parameter",
-            "description": "Description of the file for import/export types",
-            "datatype": "text",
-            "replaces": "MyFileDescription"
-        },
-        
-        "UseWpf": {
-          "type": "parameter",
-          "description": "Enable to use WPF designer in VS (Windows only)",
-          "datatype": "bool",
-          "defaultValue": "false"
-        },
-        "UseWinForms": {
-          "type": "parameter",
-          "description": "Enable to use Windows Forms designer in VS (Windows only)",
-          "datatype": "bool",
-          "defaultValue": "false"
-        },
-        "UseWindowsDesktop": {
-          "type": "computed",
-          "value": "UseWpf || UseWinForms"
-        },
+        {
+          "choice": "8",
+          "description": "Version 8"
+        }
+      ],
+      "replaces": "MyRhinoVersion"
+    },
+    "BuildYak": {
+      "type": "parameter",
+      "description": "Include target to build yak package(s) for your plugin",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
+    "IncludeVSCode": {
+      "type": "parameter",
+      "description": "Include tasks.json and launch.json to build/debug in VS Code",
+      "datatype": "bool",
+      "defaultValue": "true"
+    },
+    "CommandClassName": {
+      "type": "parameter",
+      "description": "Name of the command class.",
+      "datatype": "text",
+      "replaces": "MyRhino__1Command",
+      "fileRename": "MyRhino__1Command"
+    },
+    "PluginClassName": {
+      "type": "parameter",
+      "description": "Name of the plugin class.",
+      "datatype": "text",
+      "replaces": "MyRhino__1Plugin",
+      "fileRename": "MyRhino__1Plugin"
+    },
+    "FileExtension": {
+      "type": "parameter",
+      "description": "Extension for file import/export plugin types (e.g. 'myext')",
+      "datatype": "text",
+      "replaces": "myext"
+    },
+    "FileDescription": {
+      "type": "parameter",
+      "description": "Description of the file for import/export types",
+      "datatype": "text",
+      "replaces": "MyFileDescription"
+    },
+    
+    "UseWpf": {
+      "type": "parameter",
+      "description": "Enable to use WPF designer in VS (Windows only)",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
+    "UseWinForms": {
+      "type": "parameter",
+      "description": "Enable to use Windows Forms designer in VS (Windows only)",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
+    "UseWindowsDesktop": {
+      "type": "computed",
+      "value": "UseWpf || UseWinForms"
+    },
 
-        "TypeUtility": {
-            "type": "computed",
-            "value": "PluginType == \"utility\""
-        },
-        "TypeDigitize": {
-            "type": "computed",
-            "value": "PluginType == \"digitize\""
-        },
-        "TypeRender": {
-            "type": "computed",
-            "value": "PluginType == \"render\""
-        },
-        "TypeImport": {
-            "type": "computed",
-            "value": "PluginType == \"import\""
-        },
-        "TypeExport": {
-            "type": "computed",
-            "value": "PluginType == \"export\""
-        },
-        "HostIdentifier": {
-            "type": "bind",
-            "binding": "HostIdentifier"
-        }
+    "TypeUtility": {
+      "type": "computed",
+      "value": "PluginType == \"utility\""
     },
-    "forms": {
-      "JsonStringEncode": {
-        "identifier": "replace",
-        "pattern": "\\\\",      
-        "replacement": "\\\\"  
-      }    
+    "TypeDigitize": {
+      "type": "computed",
+      "value": "PluginType == \"digitize\""
     },
-    "sources": [
+    "TypeRender": {
+      "type": "computed",
+      "value": "PluginType == \"render\""
+    },
+    "TypeImport": {
+      "type": "computed",
+      "value": "PluginType == \"import\""
+    },
+    "TypeExport": {
+      "type": "computed",
+      "value": "PluginType == \"export\""
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    }
+  },
+  "forms": {
+    "JsonStringEncode": {
+      "identifier": "replace",
+      "pattern": "\\\\",      
+      "replacement": "\\\\"  
+    }    
+  },
+  "sources": [
+    {
+      "modifiers": [
         {
-            "modifiers": [
-                {
-                    "condition": "PluginType != 'utility'",
-                    "exclude": [ "EmbeddedResources/plugin-utility.ico" ]
-                },
-                {
-                    "condition": "PluginType != 'digitize'",
-                    "exclude": [ "EmbeddedResources/plugin-digitize.ico" ]
-                },
-                {
-                    "condition": "PluginType != 'render'",
-                    "exclude": [ "EmbeddedResources/plugin-render.ico" ]
-                },
-                {
-                    "condition": "PluginType != 'import'",
-                    "exclude": [ "EmbeddedResources/plugin-import.ico" ]
-                },
-                {
-                    "condition": "PluginType != 'export'",
-                    "exclude": [ "EmbeddedResources/plugin-export.ico" ]
-                },
-                {
-                    "condition": "CommandClassName == 'MyRhino__1Command'",
-                    "rename": {
-                        "MyRhino__1Command.vb": "MyRhino.1Command.vb"
-                    }
-                },
-                {
-                    "condition": "PluginClassName == 'MyRhino__1Plugin'",
-                    "rename": {
-                        "MyRhino__1Plugin.vb": "MyRhino.1Plugin.vb"
-                    }
-                }
-            ]
-        }
-    ],
-    "primaryOutputs": [
-        { "path": "MyRhino.1.vbproj" },
-        { "path": "MyRhino__1Command.vb" }
-    ],
-    "guids": [
-        "ee4e2b39-d96b-4e4c-8f9d-9b6561e61b64"
-    ],
-    "postActions": [
+          "condition": "!IncludeVSCode",
+          "exclude": [ ".vscode/*.*" ]
+        },
         {
-            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-            "description": "Opens the command in the editor",
-            "manualInstructions": [],
-            "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-            "args": {
-                "files": "1"
-            },
-            "continueOnError": true
+          "condition": "PluginType != 'utility'",
+          "exclude": [ "EmbeddedResources/plugin-utility.ico" ]
+        },
+        {
+          "condition": "PluginType != 'digitize'",
+          "exclude": [ "EmbeddedResources/plugin-digitize.ico" ]
+        },
+        {
+          "condition": "PluginType != 'render'",
+          "exclude": [ "EmbeddedResources/plugin-render.ico" ]
+        },
+        {
+          "condition": "PluginType != 'import'",
+          "exclude": [ "EmbeddedResources/plugin-import.ico" ]
+        },
+        {
+          "condition": "PluginType != 'export'",
+          "exclude": [ "EmbeddedResources/plugin-export.ico" ]
+        },
+        {
+          "condition": "CommandClassName == 'MyRhino__1Command'",
+          "rename": {
+            "MyRhino__1Command.vb": "MyRhino.1Command.vb"
+          }
+        },
+        {
+          "condition": "PluginClassName == 'MyRhino__1Plugin'",
+          "rename": {
+            "MyRhino__1Plugin.vb": "MyRhino.1Plugin.vb"
+          }
         }
-    ]
+      ]
+    }
+  ],
+  "primaryOutputs": [
+    { "path": "MyRhino.1.vbproj" },
+    { "path": "MyRhino__1Command.vb" }
+  ],
+  "guids": [
+    "ee4e2b39-d96b-4e4c-8f9d-9b6561e61b64"
+  ],
+  "postActions": [
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens the command in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
 }

--- a/Rhino.Templates/content/VBRhino/.vscode/launch.json
+++ b/Rhino.Templates/content/VBRhino/.vscode/launch.json
@@ -2,19 +2,41 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch Rhino 8",
+      "name": "Rhino 8 - netcore",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
       "program": "",
       "osx": {
-        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros"
+        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros",
+        "args": [],
       },
       "windows": {
         "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
         "targetArchitecture": "x86_64",
+        "args": [
+          "/netcore"
+        ]
       },
-      "args": [],
+      "env": {
+        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
+      },
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "internalConsole"
+    },
+    {
+      "name": "Rhino 8 Windows - netfx",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "windows": {
+        "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+        "targetArchitecture": "x86_64",
+        "args": [
+          "/netfx"
+        ]
+      },
       "env": {
         "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
       },
@@ -24,7 +46,7 @@
     },
 //#if (RhinoVersion <= '7')
     {
-      "name": "Launch Rhino 7 Mac",
+      "name": "Rhino 7 Mac",
       "type": "rhino",
       "request": "launch",
       "preLaunchTask": "build",
@@ -38,7 +60,7 @@
       "console": "internalConsole"
     },
     {
-      "name": "Launch Rhino 7 Windows",
+      "name": "Rhino 7 Windows",
       "type": "clr",
       "request": "launch",
       "preLaunchTask": "build",
@@ -55,7 +77,7 @@
 //#endif
 //#if (RhinoVersion <= '6')
     {
-      "name": "Launch Rhino 6 Mac",
+      "name": "Rhino 6 Mac",
       "type": "rhino",
       "request": "launch",
       "preLaunchTask": "build",
@@ -69,7 +91,7 @@
       "console": "internalConsole"
     },
     {
-      "name": "Launch Rhino 6 Windows",
+      "name": "Rhino 6 Windows",
       "type": "clr",
       "request": "launch",
       "preLaunchTask": "build",

--- a/Rhino.Templates/content/VBRhino/.vscode/launch.json
+++ b/Rhino.Templates/content/VBRhino/.vscode/launch.json
@@ -1,0 +1,89 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Rhino 8",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "",
+      "osx": {
+        "program": "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros"
+      },
+      "windows": {
+        "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+        "targetArchitecture": "x86_64",
+      },
+      "args": [],
+      "env": {
+        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/bin/Debug"
+      },
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "internalConsole"
+    },
+//#if (RhinoVersion <= '7')
+    {
+      "name": "Launch Rhino 7 Mac",
+      "type": "rhino",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "/Applications/Rhino 7.app/Contents/MacOS/Rhinoceros",
+      "args": [],
+      "env": {
+        "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net48/MyRhino.1.rhp",
+        // "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net48/MyRhino.1.gha"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+    {
+      "name": "Launch Rhino 7 Windows",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
+      "targetArchitecture": "x86_64",
+      "args": [
+        "${workspaceFolder}/bin/Debug/net48/MyRhino.1.rhp"
+      ],
+      "env": {
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+//#endif
+//#if (RhinoVersion <= '6')
+    {
+      "name": "Launch Rhino 6 Mac",
+      "type": "rhino",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "/Applications/Rhinoceros.app/Contents/MacOS/Rhinoceros",
+      "args": [],
+      "env": {
+        "RHINO_PLUGIN_PATH": "${workspaceFolder}/bin/Debug/net45/MyRhino.1.rhp",
+        // "GRASSHOPPER_PLUGINS": "${workspaceFolder}/bin/Debug/net45/MyRhino.1.gha"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+    {
+      "name": "Launch Rhino 6 Windows",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
+      "targetArchitecture": "x86_64",
+      "args": [
+        "${workspaceFolder}/bin/Debug/net45/MyRhino.1.rhp"
+      ],
+      "env": {
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole"
+    },
+//#endif
+  ],
+  "compounds": []
+}

--- a/Rhino.Templates/content/VBRhino/.vscode/tasks.json
+++ b/Rhino.Templates/content/VBRhino/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "build",
+        "-clp:NoSummary",
+        "${workspaceFolder}/MyRhino.1.vbproj"
+      ],
+      "problemMatcher": "$msCompile",
+      "presentation": {
+        "reveal": "always",
+        "clear": true
+      },
+      "group": "build"
+    }
+  ]
+}

--- a/Rhino.Templates/content/VBRhino/MyRhino.1.vbproj
+++ b/Rhino.Templates/content/VBRhino/MyRhino.1.vbproj
@@ -26,15 +26,20 @@
 <!--#endif-->
 <!--#endif-->
     <EnableDynamicLoading>true</EnableDynamicLoading>
-    <Version>1.0</Version>
-    <Title>MyRhino.1</Title>
-    <Description>Description of MyRhino.1</Description>
 <!--#if (UseWinForms)-->
     <NoWarn>NU1701;NETSDK1086</NoWarn>
 <!--#else-->
     <NoWarn>NU1701</NoWarn>
 <!--#endif-->
     <EnableWindowsTargeting Condition="$(UseWindowsDesktop) == 'True'">true</EnableWindowsTargeting>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- Specifies information for Assembly and Yak -->
+    <Version>1.0</Version>
+    <Title>MyRhino.1</Title>
+    <Company>MyRhino.1 Authors</Company>
+    <Description>Description of MyRhino.1</Description>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Rhino.Templates/content/VBRhino/MyRhino.1.vbproj
+++ b/Rhino.Templates/content/VBRhino/MyRhino.1.vbproj
@@ -1,34 +1,119 @@
-﻿<!--#if (UseWindowsDesktop)-->
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-<!--#else-->
-<Project Sdk="Microsoft.NET.Sdk">
-<!--#endif-->
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	
   <PropertyGroup>
-    <TargetFramework Condition="$(RhinoVersion) == '6'">net45</TargetFramework>
-    <TargetFramework Condition="$(RhinoVersion) == '7'">net48</TargetFramework>
-    <TargetFrameworks Condition="$(RhinoVersion) == '8'">net7.0;net48</TargetFrameworks>
+    <!-- Select the framework(s) you wish to target.
+        Rhino 6: net45
+        Rhino 7: net48
+        Rhino 8 Windows: net48, net7.0, net7.0-windows, net7.0-windows10.0.22000.0, etc
+        Rhino 8 Mac: net7.0, net7.0-macos, net7.0-macos12.0, etc
+    -->
+<!--#if (RhinoVersion == '6')-->
+<!--#if (UseWpf)-->
+    <TargetFrameworks>net7.0-windows;net48;net45</TargetFrameworks>
+<!--#elif (UseWindowsDesktop)-->
+    <TargetFrameworks>net7.0-windows;net7.0;net48;net45</TargetFrameworks>
+<!--#else-->
+    <TargetFrameworks>net7.0;net48;net45</TargetFrameworks>
+<!--#endif-->
+<!--#endif-->
+<!--#if (RhinoVersion >= '7')-->
+<!--#if (UseWpf)-->
+    <TargetFrameworks>net7.0-windows;net48</TargetFrameworks>
+<!--#elif (UseWindowsDesktop)-->
+    <TargetFrameworks>net7.0-windows;net7.0;net48</TargetFrameworks>
+<!--#else-->
+    <TargetFrameworks>net7.0;net48</TargetFrameworks>
+<!--#endif-->
+<!--#endif-->
+    <EnableDynamicLoading>true</EnableDynamicLoading>
     <Version>1.0</Version>
     <Title>MyRhino.1</Title>
     <Description>Description of MyRhino.1</Description>
-    <UseWpf Condition="$(UseWpf) == 'True'">true</UseWpf>
-    <UseWindowsForms Condition="$(UseWinForms) == 'True'">true</UseWindowsForms>
+<!--#if (UseWinForms)-->
+    <NoWarn>NU1701;NETSDK1086</NoWarn>
+<!--#else-->
+    <NoWarn>NU1701</NoWarn>
+<!--#endif-->
+    <EnableWindowsTargeting Condition="$(UseWindowsDesktop) == 'True'">true</EnableWindowsTargeting>
+  </PropertyGroup>
+  
+  <ItemGroup>
+<!--#if (RhinoVersion <= '6')-->
+    <PackageReference Include="Grasshopper" Version="6.35.21222.17001" Condition="$(TargetFramework) == 'net45'" ExcludeAssets="runtime" />
+<!--#endif-->
+<!--#if (RhinoVersion <= '7')-->
+    <PackageReference Include="Grasshopper" Version="7.0.20314.3001" Condition="$(TargetFramework) == 'net48'" ExcludeAssets="runtime" />
+    <PackageReference Include="Grasshopper" Version="8.0.23304.9001" Condition="!$(TargetFramework.StartsWith('net4'))" ExcludeAssets="runtime" />
+<!--#endif-->
+<!--#if (RhinoVersion == '8')-->
+    <PackageReference Include="Grasshopper" Version="8.0.23304.9001" ExcludeAssets="runtime" />
+<!--#endif-->
+  </ItemGroup>
+  
+<!--#if (UseWindowsDesktop)-->
+  <!-- For Windows only builds -->
+  <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))">
+<!--#if (UseWinForms)-->
+    <UseWindowsForms>true</UseWindowsForms>
+<!--#endif-->
+<!--#if (UseWpf)-->
+    <UseWpf>true</UseWpf>
+<!--#endif-->
   </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="EmbeddedResources\**\*" />
+<!--#endif-->
+<!--#if (UseWinForms)-->
+  <!-- Reference WinForms for .NET 7.0 on macOS -->
+  <ItemGroup Condition="!($(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4')))">
+    <!-- Rhino 8.11 and later you can use this -->
+    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
+    
+    <!-- Rhino 8.10 and earlier -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
+    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" ExcludeAssets="runtime" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NetFramework.ReferenceAssemblies" Version="1.0.0" />
-    <PackageReference Include="RhinoCommon" Version="6.35.21222.17001" Condition="$(RhinoVersion) == '6'" IncludeAssets="compile;build" />
-    <PackageReference Include="RhinoCommon" Version="7.13.21348.13001" Condition="$(RhinoVersion) == '7'" IncludeAssets="compile;build" />
-    <PackageReference Include="RhinoCommon" Version="8.0.23164.14305-wip" Condition="$(RhinoVersion) == '8'" IncludeAssets="compile;build" />
-  </ItemGroup>
-  
+
+<!--#endif-->
   <Target Name="RenameAssembly" AfterTargets="AfterBuild">
     <Move SourceFiles="$(TargetPath)" DestinationFiles="$(TargetDir)$(TargetName).rhp" />
-    <Move SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFiles="$(TargetDir)$(TargetName).rhp.pdb" Condition="$([MSBuild]::IsOSPlatform(OSX))" />
+<!--#if (RhinoVersion < '8')-->
+    <!-- Enable debugging in Rhino 6/7 on Mac -->
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFiles="$(TargetDir)$(TargetName).rhp.pdb" Condition="$([MSBuild]::IsOSPlatform(OSX)) and $(TargetFramework.StartsWith('net4')) and Exists('$(TargetDir)$(TargetName).pdb')" />
+<!--#endif-->
   </Target>
 
+<!--#if (BuildYak)-->
+  <Target Name="BuildYakPackage" AfterTargets="DispatchToInnerBuilds">
+    <PropertyGroup>
+      <YakExecutable Condition="$(YakExecutable) == '' and $([MSBuild]::IsOSPlatform(windows)) and Exists('C:\Program Files\Rhino 8\System\Yak.exe')">C:\Program Files\Rhino 8\System\Yak.exe</YakExecutable>
+      <YakExecutable Condition="$(YakExecutable) == '' and $([MSBuild]::IsOSPlatform(macos)) and Exists('/Applications/Rhino 8.app/Contents/Resources/bin/yak')">/Applications/Rhino 8.app/Contents/Resources/bin/yak</YakExecutable>
+      
+      <BuildYakPackage Condition="$(BuildYakPackage) == '' and $(YakExecutable) != '' and Exists($(YakExecutable))">True</BuildYakPackage>
+    </PropertyGroup>
+    
+    <Warning Text="Could not find Yak executable" Condition="$(YakExecutable) == ''" />
+
+    <ItemGroup>
+      <YakPackagesToDelete Include="$(OutputPath)\*.yak;$(OutputPath)\**\manifest.yml" />
+    </ItemGroup>
+    
+    <Delete Files="@(YakPackagesToDelete)" />
+
+    <Exec Command="&quot;$(YakExecutable)&quot; spec" WorkingDirectory="$(OutputPath)" Condition="$(BuildYakPackage) == 'True'" />
+    <Exec Command="&quot;$(YakExecutable)&quot; build" WorkingDirectory="$(OutputPath)" Condition="$(BuildYakPackage) == 'True'" />
+
+<!--#if (RhinoVersion <= '7')-->
+    <!-- Rhino 7 -->
+    <Exec Command="&quot;$(YakExecutable)&quot; spec" WorkingDirectory="$(OutputPath)net48\" Condition="$(BuildYakPackage) == 'True'" />
+    <Exec Command="&quot;$(YakExecutable)&quot; build" WorkingDirectory="$(OutputPath)net48\" Condition="$(BuildYakPackage) == 'True'" />
+    
+    <ItemGroup>
+      <YakPackageToMove Include="$(BaseOutputPath)$(Configuration)\net48\*.yak" />
+    </ItemGroup>
+    <Move SourceFiles="@(YakPackageToMove)" DestinationFolder="$(BaseOutputPath)$(Configuration)\" Condition="$(BuildYakPackage) == 'True'" />
+<!--#endif-->
+  </Target>
+
+<!--#endif-->
 </Project>

--- a/Rhino.Templates/content/VBRhino/Properties/launchSettings.json
+++ b/Rhino.Templates/content/VBRhino/Properties/launchSettings.json
@@ -1,9 +1,36 @@
 {
   "profiles": {
-    "MyRhino.1": {
+//#if (RhinoVersion <= '8')
+    "Rhino 8 netcore": {
       "commandName": "Executable",
-      "executablePath": "MyExecutablePath",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netcore",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
+      }
+    },
+    "Rhino 8 netfx": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netfx",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
+      }
+    },
+//#endif
+//#if (RhinoVersion <= '7')
+    "Rhino 7": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
+      "commandLineArgs": "$(TargetPath)"
+    },
+//#endif
+//#if (RhinoVersion <= '6')
+    "Rhino 6": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
       "commandLineArgs": "$(TargetPath)"
     }
+//#endif
   }
 }

--- a/Rhino.Templates/content/VBRhino/Properties/launchSettings.json
+++ b/Rhino.Templates/content/VBRhino/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "profiles": {
 //#if (RhinoVersion <= '8')
-    "Rhino 8 netcore": {
+    "Rhino 8 - netcore": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
       "commandLineArgs": "/netcore",
@@ -9,7 +9,7 @@
         "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
       }
     },
-    "Rhino 8 netfx": {
+    "Rhino 8 - netfx": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
       "commandLineArgs": "/netfx",

--- a/Rhino.Templates/content/VBZooPlugIn/.template.config/template.json
+++ b/Rhino.Templates/content/VBZooPlugIn/.template.config/template.json
@@ -18,7 +18,7 @@
             "type": "parameter",
             "description": "Path to ZooPlugin.dll",
             "datatype": "string",
-            "replaces": "C:\\Program Files (x86)\\Zoo 7\\ZooPlugin.dll"
+            "replaces": "C:\\Program Files (x86)\\Zoo 8\\ZooPlugin.dll"
         },
         "RhinoPluginId": {
             "type": "parameter",

--- a/Rhino.VisualStudio.Mac/Properties/AddinInfo.cs
+++ b/Rhino.VisualStudio.Mac/Properties/AddinInfo.cs
@@ -4,7 +4,7 @@ using Mono.Addins;
 [assembly: Addin(
     "Mac",
     Namespace = "Rhino.VisualStudio",
-    Version = "8.0.0.0"
+    Version = "8.10.0.0"
 )]
 
 // This controls the displayed name in the Xamarin Studio Add-In Manager...

--- a/Rhino.VisualStudio.Mac/Rhino.VisualStudio.Mac.csproj
+++ b/Rhino.VisualStudio.Mac/Rhino.VisualStudio.Mac.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
       <IncludeAssets>compile;build;native;contentfiles;analyzers;buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="Eto.Platform.XamMac2" Version="2.7.2" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>

--- a/Rhino.VisualStudio.Windows/2019/source.extension.vsixmanifest
+++ b/Rhino.VisualStudio.Windows/2019/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="F9D86CA0-D45A-42B6-ABA4-77AE7471C34F" Version="8.0.0.0" Language="en-US" Publisher="McNeel" />
+        <Identity Id="F9D86CA0-D45A-42B6-ABA4-77AE7471C34F" Version="8.10.0.0" Language="en-US" Publisher="McNeel" />
         <DisplayName>Project templates for Rhino 3D</DisplayName>
         <Description xml:space="preserve">Adds plug-in, command and zoo wizards for C++, RhinoCommon and Grasshopper projects. This includes digitizer, render, import and export plug-ins. Makes setting up debugging easier and automatically references RhinoCommon. Rhino is a requirement for this wizard to operate correctly.
 

--- a/Rhino.VisualStudio.Windows/2022/source.extension.vsixmanifest
+++ b/Rhino.VisualStudio.Windows/2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="FE5E3652-EEDC-4A36-AE44-9061466EBEE7" Version="8.0.0.0" Language="en-US" Publisher="McNeel" />
+        <Identity Id="FE5E3652-EEDC-4A36-AE44-9061466EBEE7" Version="8.10.0.0" Language="en-US" Publisher="McNeel" />
         <DisplayName>Project templates for Rhino 3D</DisplayName>
         <Description xml:space="preserve">Adds plug-in, command and zoo wizards for C++, RhinoCommon and Grasshopper projects. This includes digitizer, render, import and export plug-ins. Makes setting up debugging easier and automatically references RhinoCommon. Rhino is a requirement for this wizard to operate correctly.
 

--- a/Rhino.VisualStudio.Windows/Properties/AssemblyInfo.cs
+++ b/Rhino.VisualStudio.Windows/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.0.0.0")]
+[assembly: AssemblyVersion("8.10.0.0")]
 

--- a/Rhino.VisualStudio.Windows/Rhino.VisualStudio.Windows.csproj
+++ b/Rhino.VisualStudio.Windows/Rhino.VisualStudio.Windows.csproj
@@ -149,6 +149,10 @@
     <PackageReference Include="Eto.Platform.Wpf" Version="2.7.5" />
   </ItemGroup>
   <ItemGroup>
+    <Page Include="themes\Common.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="themes\WindowStyles.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/Rhino.VisualStudio.Windows/Templates/CPPCommand/command.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/CPPCommand/command.vstemplate
@@ -23,7 +23,7 @@
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>
-        <Assembly>Rhino.VisualStudio.Windows, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+        <Assembly>Rhino.VisualStudio.Windows, Version=8.10.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
         <FullClassName>Rhino.VisualStudio.Windows.Wizard.LegacyTemplateWizard</FullClassName>
     </WizardExtension>
     <!-- Doesn't work for C++ projects so we do it the old way..

--- a/Rhino.VisualStudio.Windows/Templates/CSGrasshopper/grasshopper.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/CSGrasshopper/grasshopper.vstemplate
@@ -29,7 +29,7 @@
             <CustomParameter Name="$uistyle$" Value="none"/>
             <CustomParameter Name="$groupid$" Value="Grasshopper.Component" />
             <CustomParameter Name="SideWaffleNewProjNode" Value="Project\CSharp\Rhino"/>
-            <CustomParameter Name="SupportedParameters" Value="ExecutableLocation;WindowsDesktop"/>
+            <CustomParameter Name="SupportedParameters" Value="ExecutableLocation;WindowsDesktop;Yak;VSCode"/>
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/CSGrasshopper/grasshopper.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/CSGrasshopper/grasshopper.vstemplate
@@ -33,7 +33,7 @@
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>
-        <Assembly>Rhino.VisualStudio.Windows, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+        <Assembly>Rhino.VisualStudio.Windows, Version=8.10.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
         <FullClassName>Rhino.VisualStudio.Windows.Wizard.GrasshopperWizard</FullClassName>
     </WizardExtension>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/CSRhino/rhino.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/CSRhino/rhino.vstemplate
@@ -29,7 +29,7 @@
             <CustomParameter Name="$uistyle$" Value="none"/>
             <CustomParameter Name="$groupid$" Value="Rhino.Plugin" />
             <CustomParameter Name="SideWaffleNewProjNode" Value="Project\CSharp\Rhino"/>
-            <CustomParameter Name="SupportedParameters" Value="ExecutableLocation;WindowsDesktop"/>
+            <CustomParameter Name="SupportedParameters" Value="ExecutableLocation;WindowsDesktop;Yak;VSCode"/>
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/CSRhino/rhino.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/CSRhino/rhino.vstemplate
@@ -33,7 +33,7 @@
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>
-        <Assembly>Rhino.VisualStudio.Windows, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+        <Assembly>Rhino.VisualStudio.Windows, Version=8.10.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
         <FullClassName>Rhino.VisualStudio.Windows.Wizard.RhinoWizard</FullClassName>
     </WizardExtension>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/CSZooPlugin/zooplugin.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/CSZooPlugin/zooplugin.vstemplate
@@ -33,7 +33,7 @@ Also, remember to copy the ID from your Rhino plug-in before continuing.</Descri
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>
-        <Assembly>Rhino.VisualStudio.Windows, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+        <Assembly>Rhino.VisualStudio.Windows, Version=8.10.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
         <FullClassName>Rhino.VisualStudio.Windows.Wizard.ZooPluginWizard</FullClassName>
     </WizardExtension>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/CppRhino/rhino.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/CppRhino/rhino.vstemplate
@@ -32,7 +32,7 @@
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>
-        <Assembly>Rhino.VisualStudio.Windows, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+        <Assembly>Rhino.VisualStudio.Windows, Version=8.10.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
         <FullClassName>Rhino.VisualStudio.Windows.Wizard.CppRhinoWizard</FullClassName>
     </WizardExtension>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/CppSkin/skin.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/CppSkin/skin.vstemplate
@@ -32,7 +32,7 @@
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>
-        <Assembly>Rhino.VisualStudio.Windows, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+        <Assembly>Rhino.VisualStudio.Windows, Version=8.10.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
         <FullClassName>Rhino.VisualStudio.Windows.Wizard.CppSkinWizard</FullClassName>
     </WizardExtension>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/VBGrasshopper/grasshopper.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/VBGrasshopper/grasshopper.vstemplate
@@ -33,7 +33,7 @@
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>
-        <Assembly>Rhino.VisualStudio.Windows, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+        <Assembly>Rhino.VisualStudio.Windows, Version=8.10.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
         <FullClassName>Rhino.VisualStudio.Windows.Wizard.GrasshopperWizard</FullClassName>
     </WizardExtension>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/VBGrasshopper/grasshopper.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/VBGrasshopper/grasshopper.vstemplate
@@ -29,7 +29,7 @@
             <CustomParameter Name="$uistyle$" Value="none"/>
             <CustomParameter Name="$groupid$" Value="Grasshopper.Component" />
             <CustomParameter Name="SideWaffleNewProjNode" Value="Project\VisualBasic\Rhino"/>
-            <CustomParameter Name="SupportedParameters" Value="ExecutableLocation;WindowsDesktop"/>
+            <CustomParameter Name="SupportedParameters" Value="ExecutableLocation;WindowsDesktop;Yak;VSCode"/>
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/VBRhino/rhino.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/VBRhino/rhino.vstemplate
@@ -29,7 +29,7 @@
             <CustomParameter Name="$uistyle$" Value="none"/>
             <CustomParameter Name="$groupid$" Value="Rhino.Plugin" />
             <CustomParameter Name="SideWaffleNewProjNode" Value="Project\VisualBasic\Rhino"/>
-            <CustomParameter Name="SupportedParameters" Value="ExecutableLocation;WindowsDesktop"/>
+            <CustomParameter Name="SupportedParameters" Value="ExecutableLocation;WindowsDesktop;Yak;VSCode"/>
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/VBRhino/rhino.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/VBRhino/rhino.vstemplate
@@ -33,7 +33,7 @@
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>
-        <Assembly>Rhino.VisualStudio.Windows, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+        <Assembly>Rhino.VisualStudio.Windows, Version=8.10.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
         <FullClassName>Rhino.VisualStudio.Windows.Wizard.RhinoWizard</FullClassName>
     </WizardExtension>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/Templates/VBZooPlugin/zooplugin.vstemplate
+++ b/Rhino.VisualStudio.Windows/Templates/VBZooPlugin/zooplugin.vstemplate
@@ -33,7 +33,7 @@ Also, remember to copy the ID from your Rhino plug-in before continuing.</Descri
         </CustomParameters>
     </TemplateContent>
     <WizardExtension>
-        <Assembly>Rhino.VisualStudio.Windows, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+        <Assembly>Rhino.VisualStudio.Windows, Version=8.10.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
         <FullClassName>Rhino.VisualStudio.Windows.Wizard.ZooPluginWizard</FullClassName>
     </WizardExtension>
     <WizardExtension>

--- a/Rhino.VisualStudio.Windows/themes/Common.xaml
+++ b/Rhino.VisualStudio.Windows/themes/Common.xaml
@@ -1,0 +1,29 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:eto="clr-namespace:Eto.Wpf.Forms.Controls;assembly=Eto.Wpf" 
+                    xmlns:tree="clr-namespace:Eto.Wpf.CustomControls.TreeGridView;assembly=Eto.Wpf" 
+                    xmlns:s="clr-namespace:System;assembly=System" 
+                    xmlns:theme="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2"
+                    xmlns:vsp="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0">
+
+
+    <Style x:Key="FocusVisual">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="2" StrokeDashArray="1 2" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" SnapsToDevicePixels="true" StrokeThickness="1"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="OptionMarkFocusVisual">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="14,0,0,0" StrokeDashArray="1 2" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" SnapsToDevicePixels="true" StrokeThickness="1"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/Rhino.VisualStudio.Windows/themes/WindowStyles.xaml
+++ b/Rhino.VisualStudio.Windows/themes/WindowStyles.xaml
@@ -7,6 +7,7 @@
 
   <!-- Set all control styles to match VS theme (dark/light/blue/etc) -->
     <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="Common.xaml" />
         <ResourceDictionary Source="ComboBox.xaml" />
         <ResourceDictionary Source="ComboBoxItem.xaml" />
     </ResourceDictionary.MergedDictionaries>

--- a/Rhino.VisualStudio/BaseDesktopWizardViewModel.cs
+++ b/Rhino.VisualStudio/BaseDesktopWizardViewModel.cs
@@ -3,6 +3,8 @@
     public abstract class BaseDesktopWizardViewModel : BaseLocationWizardViewModel
     {
         public bool ShowWindowsDesktop => Host.IsSupportedParameter("WindowsDesktop");
+        public bool SupportsYak => Host.IsSupportedParameter("Yak");
+        public bool SupportsVSCode => Host.IsSupportedParameter("VSCode");
 
         bool _useWpf;
         public bool UseWpf
@@ -18,6 +20,20 @@
             set => Set(ref _useWinForms, value);
         }
 
+        bool _buildYak;
+        public bool BuildYak
+        {
+            get => _buildYak;
+            set => Set(ref _buildYak, value);
+        }
+
+        bool _includeVSCode = true;
+        public bool IncludeVSCode
+        {
+            get => _includeVSCode;
+            set => Set(ref _includeVSCode, value);
+        }
+
         public override void Finish()
         {
             base.Finish();
@@ -28,6 +44,15 @@
             {
                 Host.SetParameter("UseWpf", UseWpf.ToString());
                 Host.SetParameter("UseWinForms", UseWinForms.ToString());
+            }
+
+            if (SupportsYak)
+            {
+                Host.SetParameter("BuildYak", BuildYak.ToString());
+            }
+            if (SupportsVSCode)
+            {
+                Host.SetParameter("IncludeVSCode", IncludeVSCode.ToString());
             }
         }
     }

--- a/Rhino.VisualStudio/BaseRhinoPageView.cs
+++ b/Rhino.VisualStudio/BaseRhinoPageView.cs
@@ -48,7 +48,7 @@ namespace Rhino.VisualStudio
             var rhinoVersionInvalid = new Label { TextColor = Global.Theme.ErrorForeground };
             rhinoVersionInvalid.BindDataContext(c => c.Visible, Binding.Property((BaseRhinoOptionsViewModel m) => m.IsRhinoVersionValid).Convert(v => !v, v => !v));
             rhinoVersionInvalid.BindDataContext(c => c.Text, (BaseRhinoOptionsViewModel m) => m.RhinoVersionValidationText);
-            layout.AddSeparateRow("Target Version", TableLayout.AutoSized(rhinoVersionDropDown));
+            layout.AddSeparateRow("Minimum Target Version", TableLayout.AutoSized(rhinoVersionDropDown));
             layout.Add(rhinoVersionInvalid);
         }
          
@@ -87,9 +87,11 @@ namespace Rhino.VisualStudio
             layout.Add(new PanelSeparator("Windows UI"));
             layout.BeginVertical();
             layout.Add(useWinForms);
+            layout.Add("Note: Rhino on Mac has limited support for Windows Forms and System.Drawing.");
             layout.Add(useWpf);
+            layout.Add("Note: Using WPF will limit the project to only run/compile on Windows.");
             layout.EndVertical();
-            layout.Add("Note: These options will limit the project to only run/compile on Windows.\nEto.Forms is included by default for cross-platform UI.");
+            layout.Add("Eto.Forms is included by default for cross-platform UI and graphics.");
             layout.EndVertical();
 
             layout.Load += (sender, e) =>

--- a/Rhino.VisualStudio/BaseRhinoPageView.cs
+++ b/Rhino.VisualStudio/BaseRhinoPageView.cs
@@ -74,6 +74,23 @@ namespace Rhino.VisualStudio
             return executableLocationGroup;
         }
          
+        protected virtual void AddBuildYakPackage(DynamicLayout layout)
+        {
+            var buildYakPackage = new CheckBox { Text = "Build Yak package", ToolTip = "Adds a target to the project to build yak package(s) automatically" };
+            buildYakPackage.BindDataContext(c => c.Checked, (BaseDesktopWizardViewModel m) => m.BuildYak);
+            
+            layout.Add(buildYakPackage);
+        }
+
+        protected virtual void AddIncludeVSCode(DynamicLayout layout)
+        {
+            var includeVSCode = new CheckBox { Text = "Include VS Code launch/tasks json files", ToolTip = "This enables easy building and debugging of your plugin using VS Code on Mac and Windows" };
+            includeVSCode.BindDataContext(c => c.Checked, (BaseDesktopWizardViewModel m) => m.IncludeVSCode);
+            
+            layout.Add(includeVSCode);
+        }
+         
+         
         protected virtual DynamicTable AddWindowsUI(DynamicLayout layout)
         {
             // wpf/winforms desktop

--- a/Rhino.VisualStudio/GrasshopperOptionsPanel.cs
+++ b/Rhino.VisualStudio/GrasshopperOptionsPanel.cs
@@ -91,6 +91,8 @@ namespace Rhino.VisualStudio
             layout.BeginVertical();
             layout.Add(new PanelSeparator("Options"));
             AddRhinoVersion(layout);
+            AddBuildYakPackage(layout);
+            AddIncludeVSCode(layout);
             layout.Add(provideCommandSampleCheckBox);
             layout.EndVertical();
 

--- a/Rhino.VisualStudio/GrasshopperOptionsPanel.cs
+++ b/Rhino.VisualStudio/GrasshopperOptionsPanel.cs
@@ -96,7 +96,7 @@ namespace Rhino.VisualStudio
 
             AddWindowsUI(layout);
 
-            AddRhinoLocation(layout);
+            // AddRhinoLocation(layout);
 
             Content = layout;
 

--- a/Rhino.VisualStudio/GrasshopperOptionsViewModel.cs
+++ b/Rhino.VisualStudio/GrasshopperOptionsViewModel.cs
@@ -123,6 +123,7 @@ namespace Rhino.VisualStudio
             ComponentCategory = "Category";
             ComponentSubcategory = "Subcategory";
             ComponentDescription = "Description";
+            UseWinForms = true;
         }
 
         public override void Finish()

--- a/Rhino.VisualStudio/Rhino.VisualStudio.csproj
+++ b/Rhino.VisualStudio/Rhino.VisualStudio.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Eto.Forms" Version="2.7.2" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/Rhino.VisualStudio/RhinoCommonOptionsPanel.cs
+++ b/Rhino.VisualStudio/RhinoCommonOptionsPanel.cs
@@ -51,7 +51,7 @@ namespace Rhino.VisualStudio
 
             AddWindowsUI(layout);
 
-            AddRhinoLocation(layout);
+            // AddRhinoLocation(layout);
 
             Content = layout;
 

--- a/Rhino.VisualStudio/RhinoCommonOptionsPanel.cs
+++ b/Rhino.VisualStudio/RhinoCommonOptionsPanel.cs
@@ -43,6 +43,8 @@ namespace Rhino.VisualStudio
             layout.Add(new PanelSeparator("Options"));
 
             AddRhinoVersion(layout);
+            AddBuildYakPackage(layout);
+            AddIncludeVSCode(layout);
             layout.Add(provideCommandSampleCheckBox);
 
             AddFileOptions(layout);

--- a/build/GenerateTemplates.proj
+++ b/build/GenerateTemplates.proj
@@ -6,10 +6,12 @@
     <ArtifactsDir>$(MSBuildThisFileDirectory)\..\artifacts\</ArtifactsDir>
     <TemplateDir>$(ArtifactsDir)templates\</TemplateDir>
     
+    <BuildAllProjects>true</BuildAllProjects> <!-- Set to false to just generate templates without building them -->
+    
     <BuildOptions>$(BuildOptions) -clp:NoSummary</BuildOptions>
 
-    <BuildOptions Condition="$([MSBuild]::IsOSPlatform(windows))">$(BuildOptions) /p:YakExecutable=&quot;C:\Program Files\Rhino 8\System\yak.exe&quot;</BuildOptions>
-    <BuildOptions Condition="$([MSBuild]::IsOSPlatform(osx))">$(BuildOptions) /p:YakExecutable=&quot;/Applications/Rhino 8.app/Contents/Resources/bin/yak&quot;</BuildOptions>
+    <!-- <BuildOptions Condition="$([MSBuild]::IsOSPlatform(windows))">$(BuildOptions) /p:YakExecutable=&quot;C:\Program Files\Rhino 8\System\yak.exe&quot;</BuildOptions> -->
+    <!-- <BuildOptions Condition="$([MSBuild]::IsOSPlatform(osx))">$(BuildOptions) /p:YakExecutable=&quot;/Applications/Rhino 8.app/Contents/Resources/bin/yak&quot;</BuildOptions> -->
     <!-- For debugging local versions of yak
     <BuildOptions>&quot;/p:YakExecutable=/Users/curtis/Library/Developer/Xcode/DerivedData/MacRhino-dalqjlsjnqqsltdayygnhqhgntxb/Build/Products/Debug/Rhinoceros.app/Contents/Resources/bin/yak&quot;</BuildOptions>
     -->
@@ -102,8 +104,8 @@
 
       <!-- Commands to generate then build -->
       <CppOptions Update="@(CppOptions)" GenerateCommand="dotnet new rhino -lang cpp %(CppOptions.Type) %(Version) %(Features) %(CustomName) -o &quot;$(TemplateDir)%(OutputDir)&quot;" />
-      <CppOptions Update="@(CppOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2022) /p:Platform=x64" Condition="%(VersionId) >= '8'" />
-      <CppOptions Update="@(CppOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2019) /p:Platform=x64" Condition="%(VersionId) == '7'" />
+      <CppOptions Update="@(CppOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2022) /p:Platform=x64" Condition="%(VersionId) >= '8' and $(BuildAllProjects) == 'true'" />
+      <CppOptions Update="@(CppOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2019) /p:Platform=x64" Condition="%(VersionId) == '7' and $(BuildAllProjects) == 'true'" />
       <CppOptions Update="@(CppOptions)" Command="%(CppOptions.GenerateCommand) %(CppOptions.BuildCommand)" />
       
     </ItemGroup>
@@ -129,8 +131,8 @@
 
       <!-- Commands to generate then build -->
       <CppSkinOptions Update="@(CppSkinOptions)" GenerateCommand="dotnet new rhinoskin %(Version) %(Features) -o &quot;$(TemplateDir)%(OutputDir)&quot;" />
-      <CppSkinOptions Update="@(CppSkinOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2022) /p:Platform=x64" Condition="%(VersionId) >= '8'" />
-      <CppSkinOptions Update="@(CppSkinOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2019) /p:Platform=x64" Condition="%(VersionId) == '7'" />
+      <CppSkinOptions Update="@(CppSkinOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2022) /p:Platform=x64" Condition="%(VersionId) >= '8' and $(BuildAllProjects) == 'true'"  />
+      <CppSkinOptions Update="@(CppSkinOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2019) /p:Platform=x64" Condition="%(VersionId) == '7' and $(BuildAllProjects) == 'true'" />
       <CppSkinOptions Update="@(CppSkinOptions)" Command="%(CppSkinOptions.GenerateCommand) %(CppSkinOptions.BuildCommand)" />
       
     </ItemGroup>
@@ -160,7 +162,7 @@
       <!-- generate template -->
       <RhinoOptions Update="@(RhinoOptions)" Command="dotnet new rhino -yak %(Type) %(Version) %(Desktop) -o $(TemplateDir)%(OutputDir)" />
       <!-- build template-->
-      <RhinoOptions Update="@(RhinoOptions)" Command="%(Command) &amp;&amp; cd $(TemplateDir)%(OutputDir) &amp;&amp; dotnet build $(BuildOptions)" />
+      <RhinoOptions Update="@(RhinoOptions)" Command="%(Command) &amp;&amp; cd $(TemplateDir)%(OutputDir) &amp;&amp; dotnet build $(BuildOptions)" Condition="$(BuildAllProjects) == 'true'" />
     </ItemGroup>
 
     <!-- <Message Text="dotnet new rhino %(Options.Type) -v %(Options.Version) -o $(TemplateDir)%(OutputDir)" Importance="high" /> -->
@@ -178,7 +180,7 @@
       <IncludeSample Include="Sample" Value="-sample" />
 
       <WithName Include="DefaultName" Value="" />
-      <WithName Include="CustonName" Value='-component MyComponentClassName -cname "MyComponent Name" -nick MyNickname -desc MyDescription -cat MyCategory -sub MySubcategory --addon-display-name="My Addon Name"' />
+      <WithName Include="CustonName" Value='-component MyComponentClassName -cname "MyComponent Name" -nick MyNickname -desc MyDescription -cat MyCategory -sub MySubcategory --addon-display-name="My-Addon-Name"' />
 
       <GHOptions4 Include="*" DesktopId="%(Desktop.Identity)" Desktop="%(Desktop.Value)" />
       <GHOptions3 Include="@(GHOptions4)" VersionId="%(RhinoVersion.Identity)" Version="--version %(RhinoVersion.Identity)" />
@@ -191,7 +193,7 @@
       <!-- generate template -->
       <GHOptions Update="@(GHOptions)" Command="dotnet new grasshopper -yak %(GHOptions.Sample) %(WithName) %(Version) %(Desktop) %(Language) -o $(TemplateDir)%(OutputDir)" />
       <!-- build template-->
-      <GHOptions Update="@(GHOptions)" Command="%(Command) &amp;&amp; cd $(TemplateDir)%(OutputDir) &amp;&amp; dotnet build $(BuildOptions)" />
+      <GHOptions Update="@(GHOptions)" Command="%(Command) &amp;&amp; cd $(TemplateDir)%(OutputDir) &amp;&amp; dotnet build $(BuildOptions)" Condition="$(BuildAllProjects) == 'true'" />
     </ItemGroup>
 
     <Exec Command="%(GHOptions.Command)" />
@@ -215,7 +217,7 @@
       <!-- generate template -->
       <ZooOptions Update="@(ZooOptions)" Command="dotnet new zooplugin %(ZooOptions.WithGuid) %(WithPath) -o $(TemplateDir)%(OutputDir)" />
       <!-- build template-->
-      <ZooOptions Update="@(ZooOptions)" Command="%(Command) &amp;&amp; cd $(TemplateDir)%(OutputDir) &amp;&amp; dotnet build" Condition="%(WithPathId) == 'DefaultPath'"/>
+      <ZooOptions Update="@(ZooOptions)" Command="%(Command) &amp;&amp; cd $(TemplateDir)%(OutputDir) &amp;&amp; dotnet build" Condition="%(WithPathId) == 'DefaultPath' and $(BuildAllProjects) == 'true'" />
     </ItemGroup>
 
     <Exec Command="%(ZooOptions.Command)" />

--- a/build/GenerateTemplates.proj
+++ b/build/GenerateTemplates.proj
@@ -5,12 +5,20 @@
   <PropertyGroup>
     <ArtifactsDir>$(MSBuildThisFileDirectory)\..\artifacts\</ArtifactsDir>
     <TemplateDir>$(ArtifactsDir)templates\</TemplateDir>
+    
+    <BuildOptions>$(BuildOptions) -clp:NoSummary</BuildOptions>
+
+    <BuildOptions Condition="$([MSBuild]::IsOSPlatform(windows))">$(BuildOptions) /p:YakExecutable=&quot;C:\Program Files\Rhino 8\System\yak.exe&quot;</BuildOptions>
+    <BuildOptions Condition="$([MSBuild]::IsOSPlatform(osx))">$(BuildOptions) /p:YakExecutable=&quot;/Applications/Rhino 8.app/Contents/Resources/bin/yak&quot;</BuildOptions>
+    <!-- For debugging local versions of yak
+    <BuildOptions>&quot;/p:YakExecutable=/Users/curtis/Library/Developer/Xcode/DerivedData/MacRhino-dalqjlsjnqqsltdayygnhqhgntxb/Build/Products/Debug/Rhinoceros.app/Contents/Resources/bin/yak&quot;</BuildOptions>
+    -->
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- <RhinoVersion Include="6" /> -->
+    <RhinoVersion Include="6" />
     <RhinoVersion Include="7" />
-    <!-- <RhinoVersion Include="8" /> -->
+    <RhinoVersion Include="8" />
 
     <Language Include="CS" Value="" />
     <Language Include="VB" Value="-lang VB" />
@@ -25,10 +33,15 @@
   <Target Name="GetVSMSBuild">
     <Exec Command="&quot;%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe&quot; -version &quot;[16,17)&quot; -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe"
           ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="VSMSBuild" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="VSMSBuild2019" />
+    </Exec>
+    <Exec Command="&quot;%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe&quot; -version &quot;[17,18)&quot; -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe"
+          ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="VSMSBuild2022" />
     </Exec>
     <PropertyGroup>
-      <VSMSBuild>&quot;$(VSMSBuild)&quot;</VSMSBuild>
+      <VSMSBuild2019>&quot;$(VSMSBuild2019)&quot;</VSMSBuild2019>
+      <VSMSBuild2022>&quot;$(VSMSBuild2022)&quot;</VSMSBuild2022>
     </PropertyGroup>
   </Target>
 
@@ -39,11 +52,25 @@
     <Exec Command="dotnet new uninstall Rhino.Templates" IgnoreExitCode="True" />
     <Exec Command="dotnet new install @(TemplatePackage)" />
   </Target>
+  
+  <Target Name="CreateDirectoryProps">
+    <ItemGroup>
+        <MyTextFile Include="$(TemplateDir)Directory.Build.props"/>
+        <MyItems Include="&lt;Project&gt;"/>
+        <MyItems Include="&lt;/Project&gt;"/>
+    </ItemGroup>
 
-  <Target Name="GenerateTemplates" DependsOnTargets="CleanTemplates;CppRhinoTemplates;CppSkinTemplates;RhinoCommonTemplates;GrasshopperTemplates;ZooTemplates" > 
+      <WriteLinesToFile
+          File="@(MyTextFile)"
+          Lines="@(MyItems)"
+          Overwrite="true"
+          Condition="!Exists($(MyTextFile))" />
+  </Target>
+
+  <Target Name="GenerateTemplates" DependsOnTargets="CleanTemplates;CreateDirectoryProps;GrasshopperTemplates;RhinoCommonTemplates;CppRhinoTemplates;CppSkinTemplates;ZooTemplates" > 
   </Target>
   
-  <Target Name="CppRhinoTemplates" DependsOnTargets="GetVSMSBuild">
+  <Target Name="CppRhinoTemplates" DependsOnTargets="GetVSMSBuild" Condition="$([MSBuild]::IsOSPlatform(Windows))">
     <!-- generate Rhino C++ templates -->
     <ItemGroup>
 
@@ -67,15 +94,16 @@
       <!-- Stitch everything together -->
       <CppOptions1 Include="*" TypeId="%(CppPluginType.Identity)" Type="%(CppPluginType.Value)" />
       <CppOptions2 Include="@(CppOptions1)" FeaturesId="%(CppPluginFeatures.Identity)" Features="%(CppPluginFeatures.Value)" />
-      <CppOptions3 Include="@(CppOptions2)" VersionId="%(RhinoVersion.Identity)" Version="--version %(RhinoVersion.Identity)" />
+      <CppOptions3 Include="@(CppOptions2)" VersionId="%(RhinoVersion.Identity)" Version="--version %(RhinoVersion.Identity)" Condition="%(RhinoVersion.Identity) > '6'" />
       <CppOptions Include="@(CppOptions3)" CustomNameId="%(CppCustomName.Identity)" CustomName="%(CppCustomName.Value)" PathSuffix="%(CppCustomName.PathSuffix)" />
       
       <!-- Set the output directory -->
-      <CppOptions Update="@(CppOptions)" OutputDir="CppRhino/%(TypeId).%(VersionId)%(FeaturesId)%(PathSuffix)/" />
+      <CppOptions Update="@(CppOptions)" OutputDir="CppRhino%(VersionId)/%(TypeId).%(FeaturesId)%(PathSuffix)/" />
 
       <!-- Commands to generate then build -->
       <CppOptions Update="@(CppOptions)" GenerateCommand="dotnet new rhino -lang cpp %(CppOptions.Type) %(Version) %(Features) %(CustomName) -o &quot;$(TemplateDir)%(OutputDir)&quot;" />
-      <CppOptions Update="@(CppOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild) /p:Platform=x64" />
+      <CppOptions Update="@(CppOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2022) /p:Platform=x64" Condition="%(VersionId) >= '8'" />
+      <CppOptions Update="@(CppOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2019) /p:Platform=x64" Condition="%(VersionId) == '7'" />
       <CppOptions Update="@(CppOptions)" Command="%(CppOptions.GenerateCommand) %(CppOptions.BuildCommand)" />
       
     </ItemGroup>
@@ -84,7 +112,7 @@
     
   </Target>
 
-  <Target Name="CppSkinTemplates" DependsOnTargets="GetVSMSBuild">
+  <Target Name="CppSkinTemplates" DependsOnTargets="GetVSMSBuild" Condition="$([MSBuild]::IsOSPlatform(Windows))">
     <!-- generate Rhino C++ skin templates -->
     <ItemGroup>
       <!-- Test all the different options -->
@@ -94,14 +122,15 @@
 
       <!-- Stitch everything together -->
       <CppSkinOptions1 Include="*" FeaturesId="%(CppSkinFeatures.Identity)" Features="%(CppSkinFeatures.Value)" />
-      <CppSkinOptions Include="@(CppSkinOptions1)" VersionId="%(RhinoVersion.Identity)" Version="--version %(RhinoVersion.Identity)" />
+      <CppSkinOptions Include="@(CppSkinOptions1)" VersionId="%(RhinoVersion.Identity)" Version="--version %(RhinoVersion.Identity)" Condition="%(RhinoVersion.Identity) > '6'" />
       
       <!-- Set the output directory -->
-      <CppSkinOptions Update="@(CppSkinOptions)" OutputDir="CppSkin/Skin.%(VersionId)%(FeaturesId)/" />
+      <CppSkinOptions Update="@(CppSkinOptions)" OutputDir="CppSkin%(VersionId)/Skin.%(FeaturesId)/" />
 
       <!-- Commands to generate then build -->
       <CppSkinOptions Update="@(CppSkinOptions)" GenerateCommand="dotnet new rhinoskin %(Version) %(Features) -o &quot;$(TemplateDir)%(OutputDir)&quot;" />
-      <CppSkinOptions Update="@(CppSkinOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild) /p:Platform=x64" />
+      <CppSkinOptions Update="@(CppSkinOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2022) /p:Platform=x64" Condition="%(VersionId) >= '8'" />
+      <CppSkinOptions Update="@(CppSkinOptions)" BuildCommand="&amp;&amp; cd &quot;$(TemplateDir)%(OutputDir)&quot; &amp;&amp; $(VSMSBuild2019) /p:Platform=x64" Condition="%(VersionId) == '7'" />
       <CppSkinOptions Update="@(CppSkinOptions)" Command="%(CppSkinOptions.GenerateCommand) %(CppSkinOptions.BuildCommand)" />
       
     </ItemGroup>
@@ -123,21 +152,22 @@
 
       <RhinoOptions1 Include="*" DesktopId="%(Desktop.Identity)" Desktop="%(Desktop.Value)" />
       <RhinoOptions2 Include="@(RhinoOptions1)" VersionId="%(RhinoVersion.Identity)" Version="--version %(RhinoVersion.Identity)" />
-      <RhinoOptions Include="@(RhinoOptions2)" TypeId="%(PluginType.Identity)" Type="%(PluginType.Value)" />
+      <RhinoOptions3 Include="@(RhinoOptions2)" LanguageId="%(Language.Identity)" Language="%(Language.Value)" />
+      <RhinoOptions Include="@(RhinoOptions3)" TypeId="%(PluginType.Identity)" Type="%(PluginType.Value)" />
       
-      <RhinoOptions Update="@(RhinoOptions)" OutputDir="RhinoCommon/%(TypeId).%(VersionId)%(DesktopId)/" />
+      <RhinoOptions Update="@(RhinoOptions)" OutputDir="RhinoCommon%(VersionId)/%(LanguageId)/%(TypeId).%(DesktopId)/" />
       
       <!-- generate template -->
-      <RhinoOptions Update="@(RhinoOptions)" Command="dotnet new rhino %(Type) %(Version) %(Desktop) -o $(TemplateDir)%(OutputDir)" />
+      <RhinoOptions Update="@(RhinoOptions)" Command="dotnet new rhino -yak %(Type) %(Version) %(Desktop) -o $(TemplateDir)%(OutputDir)" />
       <!-- build template-->
-      <RhinoOptions Update="@(RhinoOptions)" Command="%(Command) &amp;&amp; cd $(TemplateDir)%(OutputDir) &amp;&amp; dotnet build" />
+      <RhinoOptions Update="@(RhinoOptions)" Command="%(Command) &amp;&amp; cd $(TemplateDir)%(OutputDir) &amp;&amp; dotnet build $(BuildOptions)" />
     </ItemGroup>
 
     <!-- <Message Text="dotnet new rhino %(Options.Type) -v %(Options.Version) -o $(TemplateDir)%(OutputDir)" Importance="high" /> -->
     <Exec Command="%(RhinoOptions.Command)" />
     
     <!-- Test specifying class names for command and plugin -->
-    <Exec Command="dotnet new rhino -command SomeCommand -plugin AwesomePlugin -o $(TemplateDir)RhinoCommon/CustomNames" />
+    <Exec Command="dotnet new rhino -command SomeCommand -plugin AwesomePlugin -o $(TemplateDir)RhinoCommon8/CS/CustomNames" />
 
   </Target>
 
@@ -156,19 +186,19 @@
       <GHOptions1 Include="@(GHOptions2)" LanguageId="%(Language.Identity)" Language="%(Language.Value)" />
       <GHOptions Include="@(GHOptions1)" SampleId="%(IncludeSample.Identity)" Sample="%(IncludeSample.Value)" />
       
-      <GHOptions Update="@(GHOptions)" OutputDir="Grasshopper/%(SampleId).%(WithNameId)%(LanguageId)%(VersionId)%(DesktopId)/" />
+      <GHOptions Update="@(GHOptions)" OutputDir="Grasshopper%(VersionId)/%(LanguageId)/%(SampleId).%(WithNameId)%(DesktopId)/" />
 
       <!-- generate template -->
-      <GHOptions Update="@(GHOptions)" Command="dotnet new grasshopper %(GHOptions.Sample) %(WithName) %(Version) %(Desktop) %(Language) -o $(TemplateDir)%(OutputDir)" />
+      <GHOptions Update="@(GHOptions)" Command="dotnet new grasshopper -yak %(GHOptions.Sample) %(WithName) %(Version) %(Desktop) %(Language) -o $(TemplateDir)%(OutputDir)" />
       <!-- build template-->
-      <GHOptions Update="@(GHOptions)" Command="%(Command) &amp;&amp; cd $(TemplateDir)%(OutputDir) &amp;&amp; dotnet build" />
+      <GHOptions Update="@(GHOptions)" Command="%(Command) &amp;&amp; cd $(TemplateDir)%(OutputDir) &amp;&amp; dotnet build $(BuildOptions)" />
     </ItemGroup>
 
     <Exec Command="%(GHOptions.Command)" />
 
   </Target>
 
-  <Target Name="ZooTemplates">
+  <Target Name="ZooTemplates" Condition="$([MSBuild]::IsOSPlatform(Windows))">
     <!-- generate Zoo templates -->
     <ItemGroup>
       <WithGuid Include="NoId" Value="" />

--- a/dotnet-workloads.json
+++ b/dotnet-workloads.json
@@ -1,3 +1,3 @@
 {
-    "microsoft.net.sdk.macos": "12.3.2372"
+    "microsoft.net.sdk.macos": "13.1.2054"
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
   "sdk": {
     // "version": "5.0.400", // required for VS 2019
-    "version": "7.0.100", // required to build on Mac
-    "rollForward": "latestPatch"
+    // "version": "7.0.100", // required to build on Mac
+    "version": "8.0.100", // required to build on Mac
+    "rollForward": "latestFeature"
   }
 }

--- a/marketplace description.md
+++ b/marketplace description.md
@@ -37,5 +37,5 @@ It makes setting up debugging easier and automatically references the RhinoCommo
 
 ---
 
-(c) 2012-2023 Robert McNeel & Associates
+(c) 2012-2024 Robert McNeel & Associates
 For questions, email curtis@mcneel.com


### PR DESCRIPTION
- Support compiling with WinForms in .NET 7 on Mac
- Add VS debug targets for Rhino 8 netfx/netcore
- Include launch.json/tasks.json for VS Code to make it easier to start debugging on Mac
- Remove VS for Mac build
- Adds a target to build .yak packages for Rhino 7 and Rhino 8 if specified.

Fixes #16